### PR TITLE
MHP-1007: Translations

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["react-native"]
+  "presets": ["react-native"],
+  "plugins": ["transform-decorators-legacy"]
 }

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+ONESKY_API_KEY=onesky_placeholder_key
+ONESKY_SECRET_KEY=onesky_placeholder_secret

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ coverage/
 **/.gradle/
 **/build/
 android/app/build
+
+.env.local

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: node_js
-
 node_js:
-  - '8'
-
+- '8'
 script:
-  - yarn run test:coverage
-  - yarn run lint
-
+- yarn run test:coverage
+- yarn run lint
 notifications:
   email: false
-
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
+- bash <(curl -s https://codecov.io/bash)
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+  yarn run oneSky:upload; fi
 cache:
   yarn: true
+env:
+  global:
+  - secure: x+/ErK+mpslyOoJFQ9g5nAbriM6IbOoC2cJMat5oipsL1GYfSlf2Q/XopHEjJKm0hFenatXyhwq8qwVd2Qb+IWStWWJQ2ZKzgMJvQe8mmzMtK0fHRvr3TADMxiCn7BuBZpe7ag7r27vr0YJj1kOK0aiAiLMlGTnqMHai2B/fh34KWtWvk5Xm9wo/AE9zjOqi1pimRF3O8jfbFVxBb11RS5g3RsHRrKHtmUENdxM452fyeVlTbOjKmvFgss1E9926YYg77VJoeg1Dy8dcPKmsprn4Qcv+7BJOWJ7dLtnqHuZOnn9IrG1A8Bt8I8t/65J53MVe//40oTzuPsAJtMaRlw1k7EgDsuevQ4biMkLBuBJ7Moj8plZGwKCplyxgtvmxd7eJ1ndZlNIS5UDswqmUt66U4typH9E2wmcd56zQ8I/OcIQM24FURiCoeX2H4GTUv42KT40Tn4xOT8opVcPqNF5qYPxM8oaISBdPhR9IZyYaxecJ8rB4hbHezaW3TsXYNXihz/sIcNhAYMRc1BnbOj7hXXMgH4uFLayaq97LcqwIW/IH12p8fFlYjYJOMn3styGCgdsraTMCAfc1dC1u5EGrfEnQhc0EUlsv86P2KVm0wxuPUC8tEXq8QxYlWPhjh7cPN+M5yq6znJt61bMVR4Y/rtOt2jtAghybL7VG0SQ=
+  - secure: xU/4DwAKaz7i5bYMataoQRURNHxA6h+XSdAmgk5BL7G9cHms6Y55wx+I5hnwlY7xvxulIdUzewXaycBGDwKMxmfp9QkmFJp1IHl5etGHqBNc/GAAxh9mvPE+uBOMXMLqqKsxIuJVXNLVQKygFIZeOjUMuN3T2nBrGeVm1h9k1XQvhjaPTHasVbiEVrOCz1yEqr9e/sUZ8YYvUQwP1abrKj4UKBgekIFtxvpOyyE0VXOTLzjDRnlN52C2rFscNLAyrUGU32EL9NA/BFkDz7iv0ax01tUsZA9Ju3czcn0kvkLCjpibMqOll7UETg9vjWdyu2yp5ObEgG9zbOPijxMgBXDxuLh8DsTRjbxbn+sE1TV4Z8t+LMInQbCKkvNqiEEnJ1+O0gsZKsQbpH0x9aHgFTAcupyXgjZPCK6/lQ8U4Pe3Rtre+4fc7sdfN7qCfC0iwZKmkOCBmiF6aNxTCaMohdDuhG3dn/q4LQeDnttGBHM9Qa/2ofnh5GzrTZ/+rnVhWetsR5RicId1MfFXVqQXL37kJ+HdW4MRaY3jnaAzbx48ONUItj4l70gyT8tC/9Vj0i6JPQ4jlv0g2UcgUig2z4fzzScUvj+6PBcSyWLKOzdPaU+8zd1dyDfsMTdg0dEjsIIZs0bbnysPUuIaY2h6NebZ+3PaTX4D2xGQutTvdCY=

--- a/__mock__/react-native-device-info.js
+++ b/__mock__/react-native-device-info.js
@@ -1,0 +1,1 @@
+jest.mock('react-native-device-info');

--- a/__mock__/react-native-i18n.js
+++ b/__mock__/react-native-i18n.js
@@ -1,6 +1,0 @@
-const I18nMock = jest.mock('react-native-i18n', () => ({
-  t: jest.fn(translation => translation),
-  currentlLocale: jest.fn(() => 'en'),
-}));
-
-global.I18n = I18nMock;

--- a/__tests__/containers/__snapshots__/SetupScreen.js.snap
+++ b/__tests__/containers/__snapshots__/SetupScreen.js.snap
@@ -115,7 +115,7 @@ exports[`renders correctly 1`] = `
           ]
         }
       >
-        Profile_Label_FirstName
+        First Name (Required)
       </Text>
       <TextInput
         allowFontScaling={true}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -139,7 +139,6 @@ android {
 dependencies {
     compile project(':react-native-push-notification')
     compile project(':react-native-device-info')
-    compile project(':react-native-i18n')
     compile project(':react-native-vector-icons')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"

--- a/android/app/src/main/java/com/missionhub/MainApplication.java
+++ b/android/app/src/main/java/com/missionhub/MainApplication.java
@@ -5,7 +5,6 @@ import android.app.Application;
 import com.facebook.react.ReactApplication;
 import com.dieam.reactnativepushnotification.ReactNativePushNotificationPackage;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
-import com.AlexanderZaytsev.RNI18n.RNI18nPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -29,7 +28,6 @@ public class MainApplication extends Application implements ReactApplication {
           new MainReactPackage(),
             new ReactNativePushNotificationPackage(),
             new RNDeviceInfo(),
-            new RNI18nPackage(),
             new VectorIconsPackage()
       );
     }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -3,8 +3,6 @@ include ':react-native-push-notification'
 project(':react-native-push-notification').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-push-notification/android')
 include ':react-native-device-info'
 project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
-include ':react-native-i18n'
-project(':react-native-i18n').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-i18n/android')
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
 

--- a/bin/oneskyDownload.js
+++ b/bin/oneskyDownload.js
@@ -1,0 +1,34 @@
+import process from 'process';
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import oneSky from 'onesky-utils';
+
+dotenv.config({ path: '.env.local' });
+
+async function downloadTranslations() {
+  const options = {
+    apiKey: process.env.ONESKY_API_KEY,
+    secret: process.env.ONESKY_SECRET_KEY,
+    projectId: '292283',
+    fileName: 'en-us.json',
+    format: 'I18NEXT_MULTILINGUAL_JSON',
+  };
+
+  console.log('Downloading from OneSky...');
+  try {
+    const content = await oneSky.getMultilingualFile(options);
+    console.log('Successfully Downloaded.');
+
+    console.log('Writing translations.json...');
+    fs.writeFileSync(path.resolve(__dirname, '../src/i18n/locales/translations.json'), content);
+    console.log('Done.');
+  }
+  catch (error) {
+    console.log('Error downloading from OneSky:');
+    console.log(error);
+    process.exit(1);
+  }
+}
+
+downloadTranslations();

--- a/bin/oneskyUpload.js
+++ b/bin/oneskyUpload.js
@@ -1,0 +1,32 @@
+import process from 'process';
+import dotenv from 'dotenv';
+import oneSky from 'onesky-utils';
+import translations from '../src/i18n/locales/en-US';
+
+dotenv.config({ path: '.env.local' });
+
+async function uploadTranslations() {
+  const options = {
+    language: 'en-US',
+    apiKey: process.env.ONESKY_API_KEY,
+    secret: process.env.ONESKY_SECRET_KEY,
+    projectId: '292283',
+    fileName: 'en-us.json',
+    format: 'HIERARCHICAL_JSON',
+    content: JSON.stringify(translations),
+    keepStrings: true,
+  };
+
+  console.log('Uploading to OneSky...');
+  try {
+    await oneSky.postFile(options);
+    console.log('Successfully Uploaded.');
+  }
+  catch (error) {
+    console.log('Error uploading to OneSky:');
+    console.log(error);
+    process.exit(1);
+  }
+}
+
+uploadTranslations();

--- a/ios/MissionHub.xcodeproj/project.pbxproj
+++ b/ios/MissionHub.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };

--- a/package.json
+++ b/package.json
@@ -9,25 +9,30 @@
 		"test:snapshot": "jest -u",
 		"ios": "react-native run-ios",
 		"lint": "eslint ./src",
+		"lint:fix": "eslint ./src --fix",
 		"android": "react-native run-android",
 		"android:install:dev": "adb install android/app/build/outputs/apk/app-debug.apk",
 		"android:install:release": "adb install android/app/build/outputs/apk/app-release.apk",
 		"android:build": "react-native run-android --variant=release",
-		"precommit-msg": "echo 'Pre-commit checks...' && exit 0"
+		"precommit-msg": "echo 'Pre-commit checks...' && exit 0",
+		"onesky:upload": "babel-node ./bin/oneskyUpload.js",
+		"onesky:download": "babel-node ./bin/oneskyDownload.js"
 	},
 	"dependencies": {
 		"axios": "0.17.0",
+		"babel-plugin-transform-decorators-legacy": "^1.3.4",
 		"color": "2.0.0",
+		"i18next": "^10.2.1",
 		"jsonapi-datastore": "0.4.0-beta",
 		"lodash": "4.17.4",
 		"moment": "2.19.1",
 		"prop-types": "15.6.0",
 		"qs": "^6.5.1",
 		"react": "16.0.0",
+		"react-i18next": "^7.1.1",
 		"react-native": "0.50.4",
 		"react-native-animatable": "1.2.4",
 		"react-native-device-info": "0.12.1",
-		"react-native-i18n": "2.0.9",
 		"react-native-push-notification": "^3.0.2",
 		"react-native-scrollable-tab-view": "^0.8.0",
 		"react-native-snap-carousel": "3.4.0",
@@ -42,9 +47,12 @@
 		"uuid": "3.1.0"
 	},
 	"devDependencies": {
+		"babel-cli": "^6.26.0",
+		"babel-core": "^6.26.0",
 		"babel-eslint": "8.0.1",
 		"babel-jest": "21.2.0",
 		"babel-preset-react-native": "4.0.0",
+		"dotenv": "^4.0.0",
 		"enzyme": "3.2.0",
 		"enzyme-adapter-react-16": "1.1.0",
 		"eslint": "4.10.0",
@@ -52,6 +60,7 @@
 		"eslint-plugin-react": "7.4.0",
 		"jest": "21.2.1",
 		"jest-cli": "21.2.1",
+		"onesky-utils": "^1.2.0",
 		"pre-commit": "1.2.2",
 		"react-dom": "16.2.0",
 		"react-test-renderer": "16.0.0-beta.5"
@@ -63,7 +72,7 @@
 	"jest": {
 		"preset": "react-native",
 		"setupFiles": [
-			"<rootDir>/__mock__/react-native-i18n.js"
+			"<rootDir>/__mock__/react-native-device-info.js"
 		],
 		"transformIgnorePatterns": [
 			"node_modules/(?!(jest-)?react-native|react-navigation)"

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 // import { AppRegistry } from 'react-native';
 import { Provider } from 'react-redux';
+import { I18nextProvider } from 'react-i18next';
+import i18n from './i18n';
 
 import './utils/reactotron'; // This needs to be before the store
 import './utils/globals';
@@ -14,18 +16,20 @@ import AppWithNavigationState from './AppNavigator';
 // TODO: Add loading stuff with redux persist
 class App extends Component {
   state = { store: null };
-  
+
   componentWillMount() {
     getStore((store) => this.setState({ store }));
   }
-  
+
   render() {
     if (!this.state.store) {
       return <LoadingScreen />;
     }
     return (
       <Provider store={this.state.store}>
-        <AppWithNavigationState />
+        <I18nextProvider i18n={ i18n }>
+          <AppWithNavigationState />
+        </I18nextProvider>
       </Provider>
     );
   }

--- a/src/containers/InteractionsScreen/index.js
+++ b/src/containers/InteractionsScreen/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { View } from 'react-native';
 import { connect } from 'react-redux';
+import { translate } from 'react-i18next';
 
 import { logout } from '../../actions/auth';
 import { navigatePush } from '../../actions/navigation';
@@ -9,8 +10,11 @@ import styles from './styles';
 import { Flex, Text, Button } from '../../components/common';
 import Header, { HeaderIcon } from '../Header';
 
+@translate('interactions')
 class InteractionsScreen extends Component {
   render() {
+    const { t } = this.props;
+
     return (
       <View style={{ flex: 1 }}>
         <Header
@@ -26,7 +30,7 @@ class InteractionsScreen extends Component {
           title2="Cru at Disney College Program - Some more really long text"
         />
         <Flex align="center" justify="center" value={1} style={styles.container}>
-          <Text i18n="Interactions_Title" />
+          <Text>{t('title')}</Text>
           <Button
             onPress={() => this.props.dispatch(logout())}
             text="Logout"

--- a/src/containers/LoginScreen/index.js
+++ b/src/containers/LoginScreen/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { View, Image } from 'react-native';
+import { translate } from 'react-i18next';
 
 import { firstTime, loginWithMinistries } from '../../actions/auth';
 import { createMyPerson } from '../../actions/profile';
@@ -8,6 +9,7 @@ import styles from './styles';
 import { Text, Button, Flex } from '../../components/common';
 import { navigatePush } from '../../actions/navigation';
 
+@translate('login')
 class LoginScreen extends Component {
 
   constructor(props) {
@@ -41,6 +43,8 @@ class LoginScreen extends Component {
   }
 
   render() {
+    const { t } = this.props;
+
     return (
       <Flex style={styles.container}>
         <Flex value={.5} />
@@ -49,22 +53,22 @@ class LoginScreen extends Component {
             <View style={{paddingBottom: 20}}>
               <Image source={require('../../../assets/images/missionhub_logo_circle.png')} />
             </View>
-            <Text style={styles.text}>Grow closer to God.</Text>
-            <Text style={styles.text}>Help others experience Him.</Text>
+            <Text style={styles.text}>{t('tagline1')}</Text>
+            <Text style={styles.text}>{t('tagline2')}</Text>
           </Flex>
           <Flex value={2} align="center" justify="end">
             <Button
               pill={true}
               type="primary"
               onPress={this.loginMinistries}
-              text="SIGN UP WITH FACEBOOK"
+              text={t('facebookSignup').toUpperCase()}
               style={styles.facebookButton}
               buttonTextStyle={styles.buttonText}
             />
             <Button
               pill={true}
               onPress={this.tryItNow}
-              text="TRY IT NOW"
+              text={t('tryNow').toUpperCase()}
               style={styles.tryButton}
               buttonTextStyle={styles.buttonText}
             />
@@ -74,7 +78,7 @@ class LoginScreen extends Component {
           <Button
             type="transparent"
             onPress={this.login}
-            text="SIGN IN"
+            text={t('signIn').toUpperCase()}
             style={styles.signInButton}
             buttonTextStyle={styles.buttonText}
           />

--- a/src/containers/ProfileFields/index.js
+++ b/src/containers/ProfileFields/index.js
@@ -4,7 +4,9 @@ import { connect } from 'react-redux';
 
 import styles from './styles';
 import { Flex, Text, Button, Input } from '../../components/common';
+import {translate} from 'react-i18next';
 
+@translate('profileFields')
 class ProfileFields extends Component {
   state = {
     firstName: '',
@@ -13,7 +15,7 @@ class ProfileFields extends Component {
     phone: '',
     gender: null,
     path: null,
-  }
+  };
 
   constructor(props) {
     super(props);
@@ -27,11 +29,12 @@ class ProfileFields extends Component {
   }
 
   render() {
+    const { t } = this.props;
     const { firstName, lastName, email, phone } = this.state;
     return (
       <KeyboardAvoidingView style={styles.fieldsWrap} behavior="position">
         <Flex direction="column">
-          <Text i18n="Profile_Label_FirstName" style={styles.label} />
+          <Text style={styles.label}>{t('profileLabels.firstNameRequired')}</Text>
           <Input
             ref={(c) => this.firstName = c}
             onChangeText={(t) => this.setState({ firstName: t })}
@@ -42,7 +45,7 @@ class ProfileFields extends Component {
           />
         </Flex>
         <Flex direction="column">
-          <Text i18n="Profile_Label_LastName" style={styles.label} />
+          <Text style={styles.label}>{t('profileLabels.lastName')}</Text>
           <Input
             ref={(c) => this.lastName = c}
             onChangeText={(t) => this.setState({ lastName: t })}
@@ -53,7 +56,7 @@ class ProfileFields extends Component {
           />
         </Flex>
         <Flex direction="column">
-          <Text i18n="Profile_Label_Email" style={styles.label} />
+          <Text style={styles.label}>{t('profileLabels.email')}</Text>
           <Input
             ref={(c) => this.email = c}
             onChangeText={(t) => this.setState({ email: t })}
@@ -65,7 +68,7 @@ class ProfileFields extends Component {
           />
         </Flex>
         <Flex direction="column">
-          <Text i18n="Profile_Label_Phone" style={styles.label} />
+          <Text style={styles.label}>{t('profileLabels.phone')}</Text>
           <Input
             ref={(c) => this.phone = c}
             onChangeText={(t) => this.setState({ phone: t })}

--- a/src/containers/SetupScreen/index.js
+++ b/src/containers/SetupScreen/index.js
@@ -1,12 +1,14 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { View, Keyboard } from 'react-native';
+import {translate} from 'react-i18next';
 import styles from './styles';
 import { Button, Text, PlatformKeyboardAvoidingView, Flex } from '../../components/common';
 import Input from '../../components/Input/index';
 import { navigatePush } from '../../actions/navigation';
 import {createMyPerson, firstNameChanged, lastNameChanged} from '../../actions/profile';
 
+@translate('setup')
 class SetupScreen extends Component {
   saveAndGoToGetStarted() {
     if (this.props.firstName) {
@@ -19,6 +21,8 @@ class SetupScreen extends Component {
   }
 
   render() {
+    const { t } = this.props;
+
     return (
       <PlatformKeyboardAvoidingView>
         <Flex value={1} />
@@ -29,7 +33,7 @@ class SetupScreen extends Component {
 
         <Flex value={3} style={{padding: 30}}>
           <View>
-            <Text i18n="Profile_Label_FirstName" style={styles.label} />
+            <Text style={styles.label}>{t('profileLabels.firstNameRequired')}</Text>
             <Input
               ref={(c) => this.firstName = c}
               onChangeText={(t) => this.props.dispatch(firstNameChanged(t))}
@@ -39,7 +43,7 @@ class SetupScreen extends Component {
               blurOnSubmit={false}
               onSubmitEditing={() => this.lastName.focus()}
               style={styles.input}
-              placeholder="First Name"
+              placeholder={t('profileLabels.firstName')}
               placeholderTextColor="white"
             />
           </View>
@@ -50,7 +54,7 @@ class SetupScreen extends Component {
               onChangeText={(t) => this.props.dispatch(lastNameChanged(t))}
               value={this.props.lastName}
               returnKeyType="next"
-              placeholder="Last Name"
+              placeholder={t('profileLabels.lastName')}
               placeholderTextColor="white"
               blurOnSubmit={true}
               style={styles.input}

--- a/src/containers/WelcomeScreen/index.js
+++ b/src/containers/WelcomeScreen/index.js
@@ -1,11 +1,13 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { translate } from 'react-i18next';
 import { navigatePush } from '../../actions/navigation';
 import theme from '../../theme';
 
 import styles from './styles';
 import { Flex, Text, Button } from '../../components/common';
 
+@translate('welcome')
 class WelcomeScreen extends Component {
   navigateToNext() {
     if (this.props.auth.isLoggedIn) {
@@ -16,11 +18,13 @@ class WelcomeScreen extends Component {
   }
 
   render() {
+    const { t } = this.props;
+
     return (
       <Flex align="center" justify="center" value={1} style={styles.container}>
         <Flex value={4} align="center" justify="center">
-          <Text type="header" style={styles.headerText}>welcome!</Text>
-          <Text style={styles.descriptionText}>Growing closer to God involves helping others experience Him. MissionHub joins you in that journey by suggesting steps of faith to take with others.</Text>
+          <Text type="header" style={styles.headerText}>{t('welcome')}</Text>
+          <Text style={styles.descriptionText}>{t('welcomeDescription')}</Text>
         </Flex>
 
         <Flex value={1} align="stretch" justify="end">

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,15 +1,39 @@
-// https://github.com/AlexanderZaytsev/react-native-i18n
-import I18n from 'react-native-i18n';
+import i18n from 'i18next';
+import { reactI18nextModule } from 'react-i18next';
+import mapValues from 'lodash/mapValues';
+import {locale} from '../utils/common';
 
-import en from './locales/en.json';
-import fr from './locales/fr.json';
+import translations from './locales/translations.json';
+import en_US from './locales/en-US.js';
 
-I18n.fallbacks = true;
-
-// TODO: Add all translations correctly
-I18n.translations = {
-  en,
-  fr,
+const languageDetector = {
+  type: 'languageDetector',
+  async: false,
+  detect: () => locale,
+  init: () => {},
+  cacheUserLanguage: () => {},
 };
 
-export default I18n;
+export default i18n
+  .use(languageDetector)
+  .use(reactI18nextModule)
+  .init({
+    fallbackLng: 'en-US',
+
+    // Use downloaded translations if available but use en-US from source to make development easier
+    resources: { ...mapValues(translations, 'translation'), ...{ 'en-US': en_US } },
+
+    // have a common namespace used around the full app
+    ns: ['common'],
+    defaultNS: 'common',
+    fallbackNS: 'common',
+
+    interpolation: {
+      escapeValue: false, // not needed for react as it does escape per default to prevent xss!
+    },
+
+    react: {
+      wait: true,
+      nsMode: 'fallback',
+    },
+  });

--- a/src/i18n/locales/en-US.js
+++ b/src/i18n/locales/en-US.js
@@ -1,0 +1,25 @@
+export default {
+  common: {
+    profileLabels: {
+      firstName: 'First Name',
+      firstNameRequired: '$t(profileLabels.firstName) (Required)',
+      lastName: 'Last Name',
+      email: 'Email',
+      phone: 'Phone',
+    },
+  },
+  welcome: {
+    welcome: 'welcome!',
+    welcomeDescription: 'Growing closer to God involves helping others experience Him. MissionHub joins you in that journey by suggesting steps of faith to take with others.',
+  },
+  interactions: {
+    title: 'Hi!',
+  },
+  login: {
+    tagline1: 'Grow closer to God.',
+    tagline2: 'Help others experience Him.',
+    facebookSignup: 'Sign up with Facebook',
+    tryNow: 'Try it now',
+    signIn: 'Sign In',
+  },
+};

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,7 +1,0 @@
-{
-  "Interactions_Title": "Hi!",
-  "Profile_Label_FirstName": "First Name (Required)",
-  "Profile_Label_LastName": "Last Name",
-  "Profile_Label_Email": "Email",
-  "Profile_Label_Phone": "Phone"
-}

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1,7 +1,0 @@
-{
-  "Interactions_Title": "Bonjour!",
-  "Profile_Label_FirstName": "First Name",
-  "Profile_Label_LastName": "Last Name",
-  "Profile_Label_Email": "Email",
-  "Profile_Label_Phone": "Phone"
-}

--- a/src/i18n/locales/translations.json
+++ b/src/i18n/locales/translations.json
@@ -1,0 +1,33 @@
+{
+    "en-US": {
+        "translation": {
+            "common": {
+                "profileLabels": {
+                    "firstName": "First Name",
+                    "firstNameRequired": "$t(profileLabels.firstName) (Required)",
+                    "lastName": "Last Name",
+                    "email": "Email",
+                    "phone": "Phone"
+                },
+                "profileLabelFirstName": "First Name (Required)",
+                "profileLabelLastName": "Last Name",
+                "profileLabelEmail": "Email",
+                "profileLabelPhone": "Phone"
+            },
+            "welcome": {
+                "welcome": "welcome!",
+                "welcomeDescription": "Growing closer to God involves helping others experience Him. MissionHub joins you in that journey by suggesting steps of faith to take with others."
+            },
+            "interactions": {
+                "title": "Hi!"
+            },
+            "login": {
+                "tagline1": "Grow closer to God.",
+                "tagline2": "Help others experience Him.",
+                "facebookSignup": "Sign up with Facebook",
+                "tryNow": "Try it now",
+                "signIn": "Sign In"
+            }
+        }
+    }
+}

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -7,6 +7,7 @@ export const getFirstThreeValidItems = (arr) => {
 };
 
 export const isiPhoneX = () => DeviceInfo.getModel() === 'iPhone X';
+export const locale = DeviceInfo.getDeviceLocale();
 
 export const isFunction = (fn) => typeof fn === 'function';
 export const isArray = (arr) => Array.isArray(arr);

--- a/yarn.lock
+++ b/yarn.lock
@@ -231,6 +231,10 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
 
+async-each@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
+
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -267,6 +271,27 @@ axios@0.17.0:
   dependencies:
     follow-redirects "^1.2.3"
     is-buffer "^1.1.5"
+
+babel-cli@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
+  dependencies:
+    babel-core "^6.26.0"
+    babel-polyfill "^6.26.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    commander "^2.11.0"
+    convert-source-map "^1.5.0"
+    fs-readdir-recursive "^1.0.0"
+    glob "^7.1.2"
+    lodash "^4.17.4"
+    output-file-sync "^1.1.2"
+    path-is-absolute "^1.0.1"
+    slash "^1.0.0"
+    source-map "^0.5.6"
+    v8flags "^2.1.1"
+  optionalDependencies:
+    chokidar "^1.6.1"
 
 babel-code-frame@7.0.0-beta.0:
   version "7.0.0-beta.0"
@@ -493,6 +518,10 @@ babel-plugin-syntax-class-properties@^6.5.0, babel-plugin-syntax-class-propertie
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
+babel-plugin-syntax-decorators@^6.1.18:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+
 babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
@@ -529,6 +558,14 @@ babel-plugin-transform-class-properties@^6.18.0, babel-plugin-transform-class-pr
     babel-plugin-syntax-class-properties "^6.8.0"
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
+
+babel-plugin-transform-decorators-legacy@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.4.tgz#741b58f6c5bce9e6027e0882d9c994f04f366925"
+  dependencies:
+    babel-plugin-syntax-decorators "^6.1.18"
+    babel-runtime "^6.2.0"
+    babel-template "^6.3.0"
 
 babel-plugin-transform-define@^1.3.0:
   version "1.3.0"
@@ -734,6 +771,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-es2015-node@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015-node/-/babel-preset-es2015-node-6.1.1.tgz#60b23157024b0cfebf3a63554cb05ee035b4e55f"
@@ -836,7 +881,7 @@ babel-register@^6.24.1, babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -852,7 +897,7 @@ babel-template@7.0.0-beta.0:
     babylon "7.0.0-beta.22"
     lodash "^4.2.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.3.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -975,6 +1020,10 @@ big-integer@^1.6.7:
   version "1.6.25"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.25.tgz#1de45a9f57542ac20121c682f8d642220a34e823"
 
+binary-extensions@^1.0.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
+
 blob@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
@@ -984,6 +1033,10 @@ block-stream@*:
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+bluebird@^2.3:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
 
 body-parser@~1.13.3:
   version "1.13.3"
@@ -1110,7 +1163,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1128,6 +1181,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -1138,6 +1195,21 @@ cheerio@^1.0.0-rc.2:
     htmlparser2 "^3.9.1"
     lodash "^4.15.0"
     parse5 "^3.0.1"
+
+chokidar@^1.6.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
+  dependencies:
+    anymatch "^1.3.0"
+    async-each "^1.0.0"
+    glob-parent "^2.0.0"
+    inherits "^2.0.1"
+    is-binary-path "^1.0.0"
+    is-glob "^2.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.0.0"
+  optionalDependencies:
+    fsevents "^1.0.0"
 
 ci-info@^1.0.0:
   version "1.1.1"
@@ -1227,13 +1299,13 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.11.0, commander@~2.12.1:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
 commander@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-
-commander@~2.12.1:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
 component-bind@1.0.0:
   version "1.0.0"
@@ -1392,6 +1464,10 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -1545,6 +1621,10 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+
 diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
@@ -1605,6 +1685,10 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
 duplexer2@0.0.2:
   version "0.0.2"
@@ -2144,9 +2228,20 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
+fs-readdir-recursive@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+fsevents@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
+  dependencies:
+    nan "^2.3.0"
+    node-pre-gyp "^0.6.39"
 
 fsevents@^1.1.1:
   version "1.1.2"
@@ -2281,7 +2376,7 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2416,7 +2511,7 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.2.1:
+hoist-non-react-statics@2.3.1, hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
@@ -2436,6 +2531,12 @@ html-encoding-sniffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+html-parse-stringify2@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz#dc5670b7292ca158b7bc916c9a6735ac8872834a"
+  dependencies:
+    void-elements "^2.0.1"
 
 htmlparser2@^3.9.1:
   version "3.9.2"
@@ -2471,9 +2572,9 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-i18n-js@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-3.0.2.tgz#d14cff2562758e7d30d34ddd58dd12d53fd07b5f"
+i18next@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-10.2.1.tgz#bec61a98d7976c3084147cc2cd2bafdeff9088f2"
 
 iconv-lite@0.4.11:
   version "0.4.11"
@@ -2555,9 +2656,19 @@ is-arrayish@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.1.tgz#c2dfc386abaa0c3e33c48db3fe87059e69065efd"
 
+is-binary-path@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
+  dependencies:
+    binary-extensions "^1.0.0"
+
 is-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
+
+is-buffer@~1.1.1:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
@@ -3298,7 +3409,7 @@ lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lo
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^3.5.0:
+lodash@^3.10.0, lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
@@ -3328,6 +3439,14 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+md5@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -3585,6 +3704,22 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
+node-pre-gyp@^0.6.39:
+  version "0.6.39"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
+  dependencies:
+    detect-libc "^1.0.2"
+    hawk "3.1.3"
+    mkdirp "^0.5.1"
+    nopt "^4.0.1"
+    npmlog "^4.0.2"
+    rc "^1.1.7"
+    request "2.81.0"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^2.2.1"
+    tar-pack "^3.4.0"
+
 nomnom@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
@@ -3724,6 +3859,13 @@ once@^1.3.0, once@^1.3.3, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+onesky-utils@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/onesky-utils/-/onesky-utils-1.2.0.tgz#543dd7eb5d1153a6331283fef1f457032f6f2eff"
+  dependencies:
+    md5 "^2.0.0"
+    request-promise "^0.4.2"
+
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
@@ -3791,6 +3933,14 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+output-file-sync@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76"
+  dependencies:
+    graceful-fs "^4.1.4"
+    mkdirp "^0.5.1"
+    object-assign "^4.1.0"
 
 p-cancelable@^0.3.0:
   version "0.3.0"
@@ -4135,6 +4285,14 @@ react-dom@16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-i18next@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-7.1.1.tgz#4fb5cb4ef7f7ad4fc77cc298e92967d07d6dee75"
+  dependencies:
+    hoist-non-react-statics "2.3.1"
+    html-parse-stringify2 "2.0.1"
+    prop-types "^15.6.0"
+
 react-native-animatable@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.2.4.tgz#b5fb7657e8f6edadbc26697057a327fb920b3039"
@@ -4160,12 +4318,6 @@ react-native-drawer-layout@1.3.2:
   resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-1.3.2.tgz#b9740d7663a1dc4f88a61b9c6d93d2d948ea426e"
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
-
-react-native-i18n@2.0.9:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/react-native-i18n/-/react-native-i18n-2.0.9.tgz#cd2afcf184bbaa7244917d30a57e81e939f79b88"
-  dependencies:
-    i18n-js "^3.0.2"
 
 react-native-push-notification@^3.0.2:
   version "3.0.2"
@@ -4395,6 +4547,15 @@ readable-stream@~1.1.8, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+readdirp@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
+  dependencies:
+    graceful-fs "^4.1.2"
+    minimatch "^3.0.2"
+    readable-stream "^2.0.2"
+    set-immediate-shim "^1.0.1"
+
 redux-persist@4.10.1:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-4.10.1.tgz#4fb2b789942f10f56d51cc7ad068d9d6beb46124"
@@ -4419,6 +4580,10 @@ redux@3.7.2, redux@^3.7.1:
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.0"
@@ -4482,6 +4647,15 @@ replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
 
+request-promise@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-0.4.3.tgz#3c8ddc82f06f8908d720aede1d6794258e22121c"
+  dependencies:
+    bluebird "^2.3"
+    chalk "^1.1.0"
+    lodash "^3.10.0"
+    request "^2.34"
+
 request@2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
@@ -4509,7 +4683,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.79.0:
+request@^2.34, request@^2.79.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -4713,6 +4887,10 @@ serve-static@~1.10.0:
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+set-immediate-shim@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
 setimmediate@^1.0.5:
   version "1.0.5"
@@ -5188,6 +5366,10 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
+user-home@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
+
 util-deprecate@1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -5203,6 +5385,12 @@ uuid@3.0.1:
 uuid@3.1.0, uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+v8flags@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
+  dependencies:
+    user-home "^1.1.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
@@ -5238,6 +5426,10 @@ vinyl@^0.5.0:
     clone "^1.0.0"
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
+
+void-elements@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
- Add i18next
- Add decorators support
- Remove react-native-i18n
- Add OneSky upload and download scripts
- Run onesky:upload on travis master builds
- Add lint:fix script

I'm tagging everyone since this has implications on future development. (Yes Daniel I know you don't like me pinging everyone in code review. Too bad 😉 .)

Relevant docs for using the `t` function are under the `TRANSLATION FUNCTION` heading starting with https://www.i18next.com/essentials.html.

Let me know if you guys have any concerns with using [i18next](https://www.i18next.com/) instead of react-native-i18n which uses [I18n.js](https://github.com/fnando/i18n-js). I'm planning on using i18next for the web app also.

If this looks good, I can go through and add everything that isn't translated yet.

I've got travis uploading to OneSky on every travis master build. That should be fine as OneSky gives us 20,000 API calls for free.

Let me know if you can think of any way to automate the download. I'm not sure how the deploy process for the app stores works. Idk if that is something travis can handle. Should we store translations in github and manually download them periodically? Could we just download them when packaging an app?