### PR TITLE
Add eslint object-curly-spacing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -83,6 +83,10 @@
     "no-mixed-spaces-and-tabs": [
       "error"
     ],
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ],
     "react/jsx-indent": [
       "error",
       2

--- a/src/AppNavigator.js
+++ b/src/AppNavigator.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { addNavigationHelpers } from 'react-navigation';
-import {MainRoutes} from './AppRoutes';
+import { MainRoutes } from './AppRoutes';
 
 const AppWithNavigationState = ({ dispatch, nav }) => {
   const navigation = addNavigationHelpers({ dispatch, state: nav });

--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -39,7 +39,7 @@ import theme from './theme';
 //   },
 // });
 
-const navIcon = (name) => ({tintColor}) => <Icon type="MissionHub" name={name} size={30} style={{color: tintColor}} />;
+const navIcon = (name) => ({ tintColor }) => <Icon type="MissionHub" name={name} size={30} style={{ color: tintColor }} />;
 
 
 export const MainTabRoutes = TabNavigator({
@@ -69,10 +69,10 @@ export const MainTabRoutes = TabNavigator({
   tabBarOptions: {
     showIcon: true,
     showLabel: true,
-    style: {backgroundColor: theme.white},
+    style: { backgroundColor: theme.white },
     activeTintColor: theme.primaryColor,
     inactiveTintColor: theme.inactiveColor,
-    tabStyle: {backgroundColor: theme.lightBackgroundColor},
+    tabStyle: { backgroundColor: theme.lightBackgroundColor },
   },
   tabBarPosition: 'bottom',
   animationEnabled: false,
@@ -86,25 +86,25 @@ export const MainTabRoutes = TabNavigator({
 });
 
 export const MainStackRoutes = StackNavigator({
-  MainTabs: {screen: MainTabRoutes},
-  Profile: {screen: ProfileScreen},
-  Step: {screen: SelectMyStepScreen},
-  PersonStep: {screen: PersonSelectStepScreen},
-  AddStep: {screen: AddStepScreen},
-  Login: {screen: LoginScreen},
-  Welcome: {screen: WelcomeScreen},
-  Setup: {screen: SetupScreen},
-  GetStarted: {screen: GetStartedScreen},
-  Stage: {screen: StageScreen},
-  StageSuccess: {screen: StageSuccessScreen},
-  AddSomeone: {screen: AddSomeoneScreen},
-  Contact: {screen: ContactScreen},
-  AddContact: {screen: AddContactScreen},
-  NotificationPrimer: {screen: NotificationPrimerScreen},
-  Impact: { screen: ImpactScreen},
-  SetupPerson: {screen: SetupPersonScreen},
-  PersonStage: {screen: PersonStageScreen},
-  Celebration: {screen: CelebrationScreen},
+  MainTabs: { screen: MainTabRoutes },
+  Profile: { screen: ProfileScreen },
+  Step: { screen: SelectMyStepScreen },
+  PersonStep: { screen: PersonSelectStepScreen },
+  AddStep: { screen: AddStepScreen },
+  Login: { screen: LoginScreen },
+  Welcome: { screen: WelcomeScreen },
+  Setup: { screen: SetupScreen },
+  GetStarted: { screen: GetStartedScreen },
+  Stage: { screen: StageScreen },
+  StageSuccess: { screen: StageSuccessScreen },
+  AddSomeone: { screen: AddSomeoneScreen },
+  Contact: { screen: ContactScreen },
+  AddContact: { screen: AddContactScreen },
+  NotificationPrimer: { screen: NotificationPrimerScreen },
+  Impact: { screen: ImpactScreen },
+  SetupPerson: { screen: SetupPersonScreen },
+  PersonStage: { screen: PersonStageScreen },
+  Celebration: { screen: CelebrationScreen },
 }, {
   paths: {
     Login: 'Login',

--- a/src/actions/person.js
+++ b/src/actions/person.js
@@ -1,4 +1,4 @@
-import {PERSON_FIRST_NAME_CHANGED, PERSON_LAST_NAME_CHANGED} from '../constants';
+import { PERSON_FIRST_NAME_CHANGED, PERSON_LAST_NAME_CHANGED } from '../constants';
 
 export function personFirstNameChanged(firstName) {
   return {

--- a/src/actions/profile.js
+++ b/src/actions/profile.js
@@ -1,5 +1,5 @@
-import {FIRST_NAME_CHANGED, LAST_NAME_CHANGED} from '../constants';
-import {REQUESTS} from './api';
+import { FIRST_NAME_CHANGED, LAST_NAME_CHANGED } from '../constants';
+import { REQUESTS } from './api';
 import callApi from './api';
 import uuidv4 from 'uuid/v4';
 

--- a/src/actions/selectStage.js
+++ b/src/actions/selectStage.js
@@ -1,4 +1,4 @@
-import {REQUESTS} from './api';
+import { REQUESTS } from './api';
 import callApi from './api';
 
 export function selectStage(id) {

--- a/src/components/CustomTabs/index.js
+++ b/src/components/CustomTabs/index.js
@@ -24,10 +24,10 @@ export default class CustomTabs extends Component {
                 name={tab.iconName}
                 type="MissionHub"
                 size={32}
-                style={{color: this.props.activeTab === i ? 'rgba(255,255,255,1)' : 'rgba(255,255,255,0.4)'}}
+                style={{ color: this.props.activeTab === i ? 'rgba(255,255,255,1)' : 'rgba(255,255,255,0.4)' }}
                 ref={(icon) => { this.icons[i] = icon; }}
               />
-              <Text style={[styles.tabText, {color: this.props.activeTab === i ? 'rgba(255,255,255,1)' : 'rgba(255,255,255,0.4)'}]}>{tab.tabLabel}</Text>
+              <Text style={[styles.tabText, { color: this.props.activeTab === i ? 'rgba(255,255,255,1)' : 'rgba(255,255,255,0.4)' }]}>{tab.tabLabel}</Text>
             </TouchableOpacity>
           );
         })}

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Platform } from 'react-native';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import Material from 'react-native-vector-icons/MaterialIcons';
-import {createIconSetFromIcoMoon} from 'react-native-vector-icons';
+import { createIconSetFromIcoMoon } from 'react-native-vector-icons';
 import icoMoonConfig from '../../../assets/icoMoonConfig.json';
 import MissionHubIconGlyphs from '../../../assets/MissionHubIconGlyphs.json';
 import Ionicons from 'react-native-vector-icons/Ionicons';

--- a/src/components/IconButton/index.js
+++ b/src/components/IconButton/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {Button, Icon} from '../common';
+import { Button, Icon } from '../common';
 import styles from './styles';
 // import theme from '../../theme';
 

--- a/src/components/PlatformKeyboardAvoidingView/index.js
+++ b/src/components/PlatformKeyboardAvoidingView/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import {KeyboardAvoidingView, Platform} from 'react-native';
+import { KeyboardAvoidingView, Platform } from 'react-native';
 
 import styles from './styles';
 

--- a/src/components/PlatformKeyboardAvoidingView/styles.js
+++ b/src/components/PlatformKeyboardAvoidingView/styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import {PRIMARY_BACKGROUND_COLOR, PRIMARY_HEADER_COLOR} from '../../theme';
+import { PRIMARY_BACKGROUND_COLOR, PRIMARY_HEADER_COLOR } from '../../theme';
 
 export default StyleSheet.create({
   container: {

--- a/src/components/SecondaryTabBar/index.js
+++ b/src/components/SecondaryTabBar/index.js
@@ -17,19 +17,19 @@ export default class SecondaryTabBar extends Component {
   renderTabs(tab) {
     if (tab.page === 'steps') {
       return (
-        <Flex key={tab.iconName} style={{backgroundColor: 'white'}} value={1}>
+        <Flex key={tab.iconName} style={{ backgroundColor: 'white' }} value={1}>
           <ContactSteps />
         </Flex>
       );
     } else if (tab.page === 'journey') {
       return (
-        <Flex key={tab.iconName} style={{backgroundColor: 'white'}} value={1}>
+        <Flex key={tab.iconName} style={{ backgroundColor: 'white' }} value={1}>
           <ContactSteps />
         </Flex>
       );
     } else if (tab.page === 'notes') {
       return (
-        <Flex key={tab.iconName} style={{backgroundColor: 'white'}} value={1}>
+        <Flex key={tab.iconName} style={{ backgroundColor: 'white' }} value={1}>
           <ContactSteps />
         </Flex>
       );

--- a/src/containers/BackButton/styles.js
+++ b/src/containers/BackButton/styles.js
@@ -1,7 +1,7 @@
 
 import { StyleSheet } from 'react-native';
 import theme from '../../theme';
-import {isiPhoneX} from '../../utils/common';
+import { isiPhoneX } from '../../utils/common';
 
 const margin = 20;
 

--- a/src/containers/ContactSteps/index.js
+++ b/src/containers/ContactSteps/index.js
@@ -25,7 +25,7 @@ class ContactSteps extends Component {
   }
 
 
-  renderRow({item}) {
+  renderRow({ item }) {
     return (
       <RowSwipeable
         key={item.id}

--- a/src/containers/GetStartedScreen/index.js
+++ b/src/containers/GetStartedScreen/index.js
@@ -23,7 +23,7 @@ class GetStartedScreen extends Component {
             type="secondary"
             onPress={() => this.props.dispatch(navigatePush('Stage'))}
             text="LET'S GET STARTED"
-            style={{width: theme.fullWidth}}
+            style={{ width: theme.fullWidth }}
           />
         </Flex>
       </Flex>
@@ -31,7 +31,7 @@ class GetStartedScreen extends Component {
   }
 }
 
-const mapStateToProps = ({profile}, { navigation }) => ({
+const mapStateToProps = ({ profile }, { navigation }) => ({
   id: navigation.state.params ? navigation.state.params.id : '',
   firstName: profile.firstName,
 });

--- a/src/containers/IconMessageScreen/index.js
+++ b/src/containers/IconMessageScreen/index.js
@@ -37,7 +37,7 @@ class IconMessageScreen extends Component {
             type="secondary"
             onPress={this.handleNext}
             text={buttonText}
-            style={{width: theme.fullWidth}}
+            style={{ width: theme.fullWidth }}
           />
         </Flex>
       </Flex>

--- a/src/containers/LoginScreen/index.js
+++ b/src/containers/LoginScreen/index.js
@@ -50,7 +50,7 @@ class LoginScreen extends Component {
         <Flex value={.5} />
         <Flex value={3} align="center" justify="center">
           <Flex align="center">
-            <View style={{paddingBottom: 20}}>
+            <View style={{ paddingBottom: 20 }}>
               <Image source={require('../../../assets/images/missionhub_logo_circle.png')} />
             </View>
             <Text style={styles.text}>{t('tagline1')}</Text>

--- a/src/containers/PathwayStageScreen/index.js
+++ b/src/containers/PathwayStageScreen/index.js
@@ -1,12 +1,12 @@
-import React, {Component} from 'react';
-import {connect} from 'react-redux';
-import {navigatePush} from '../../actions/navigation';
-import {View, Image} from 'react-native';
-import {getStages} from '../../actions/stages';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { navigatePush } from '../../actions/navigation';
+import { View, Image } from 'react-native';
+import { getStages } from '../../actions/stages';
 
 import Carousel from 'react-native-snap-carousel';
 import styles from './styles';
-import {Flex, Text, Button} from '../../components/common';
+import { Flex, Text, Button } from '../../components/common';
 import LANDSCAPE from '../../../assets/images/landscape-full.png';
 import UNINTERESTED from '../../../assets/images/uninterestedIcon.png';
 import CURIOUS from '../../../assets/images/curiousIcon.png';
@@ -51,7 +51,7 @@ class PathwayStageScreen extends Component {
     });
   }
 
-  renderStage({item, index}) {
+  renderStage({ item, index }) {
     return (
       <View key={item.id} style={styles.cardWrapper}>
         <View style={styles.card}>
@@ -112,7 +112,7 @@ PathwayStageScreen.propTypes = {
   onSelect: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = ({stages}) => ({
+const mapStateToProps = ({ stages }) => ({
   stages: stages.stages,
 });
 

--- a/src/containers/PersonSelectStepScreen.js
+++ b/src/containers/PersonSelectStepScreen.js
@@ -1,10 +1,10 @@
-import React, {Component} from 'react';
-import {connect} from 'react-redux';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import SelectStepScreen from './SelectStepScreen';
 import theme from '../theme';
-import {getStepSuggestions} from '../actions/steps';
-import {getFirstThreeValidItems} from '../utils/common';
+import { getStepSuggestions } from '../actions/steps';
+import { getFirstThreeValidItems } from '../utils/common';
 
 class PersonSelectStepScreen extends Component {
   constructor(props) {

--- a/src/containers/PersonStageScreen.js
+++ b/src/containers/PersonStageScreen.js
@@ -1,8 +1,8 @@
-import React, {Component} from 'react';
-import {connect} from 'react-redux';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import PathwayStageScreen from './PathwayStageScreen';
-import {selectPersonStage} from '../actions/selectStage';
+import { selectPersonStage } from '../actions/selectStage';
 
 class PersonStageScreen extends Component {
   constructor(props) {
@@ -23,7 +23,7 @@ class PersonStageScreen extends Component {
 
 }
 
-const mapStateToProps = ({personProfile, auth}) => ({
+const mapStateToProps = ({ personProfile, auth }) => ({
   personFirstName: personProfile.personFirstName,
   personId: personProfile.id,
   id: auth.personId,

--- a/src/containers/ProfileFields/index.js
+++ b/src/containers/ProfileFields/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import styles from './styles';
 import { Flex, Text, Button, Input } from '../../components/common';
-import {translate} from 'react-i18next';
+import { translate } from 'react-i18next';
 
 @translate('profileFields')
 class ProfileFields extends Component {

--- a/src/containers/SelectMyStepScreen.js
+++ b/src/containers/SelectMyStepScreen.js
@@ -1,9 +1,9 @@
-import React, {Component} from 'react';
-import {connect} from 'react-redux';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { getStepSuggestions } from '../actions/steps';
 import SelectStepScreen from './SelectStepScreen';
-import {getFirstThreeValidItems} from '../utils/common';
+import { getFirstThreeValidItems } from '../utils/common';
 
 class SelectMyStepScreen extends Component {
   constructor(props) {

--- a/src/containers/SelectStepScreen/index.js
+++ b/src/containers/SelectStepScreen/index.js
@@ -30,7 +30,7 @@ class SelectStepScreen extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.steps.length !== this.props.steps.length) {
-      this.setState({steps: [].concat(nextProps.steps, this.state.addedSteps)});
+      this.setState({ steps: [].concat(nextProps.steps, this.state.addedSteps) });
     }
   }
 

--- a/src/containers/SetupPersonScreen.js
+++ b/src/containers/SetupPersonScreen.js
@@ -5,8 +5,8 @@ import styles from './SetupScreen/styles';
 import { Button, Text, PlatformKeyboardAvoidingView, Flex } from '../components/common';
 import Input from '../components/Input/index';
 import { navigatePush } from '../actions/navigation';
-import {personFirstNameChanged, personLastNameChanged} from '../actions/person';
-import {createPerson} from '../actions/profile';
+import { personFirstNameChanged, personLastNameChanged } from '../actions/person';
+import { createPerson } from '../actions/profile';
 
 class SetupPersonScreen extends Component {
   saveAndGoToGetStarted() {
@@ -23,11 +23,11 @@ class SetupPersonScreen extends Component {
     return (
       <PlatformKeyboardAvoidingView>
         <Flex value={1} />
-        <Flex value={2} style={{alignItems: 'center'}}>
+        <Flex value={2} style={{ alignItems: 'center' }}>
           <Image source={require('../../assets/images/add_someone.png')} />
         </Flex>
 
-        <Flex value={3} style={{padding: 30}}>
+        <Flex value={3} style={{ padding: 30 }}>
           <View>
             <Text i18n="Profile_Label_FirstName" style={styles.label} />
             <Input
@@ -44,7 +44,7 @@ class SetupPersonScreen extends Component {
             />
           </View>
 
-          <View style={{paddingTop: 30}}>
+          <View style={{ paddingTop: 30 }}>
             <Input
               ref={(c) => this.personLastName = c}
               onChangeText={(t) => this.props.dispatch(personLastNameChanged(t))}
@@ -70,7 +70,7 @@ class SetupPersonScreen extends Component {
   }
 }
 
-const mapStateToProps = ({personProfile}) => ({
+const mapStateToProps = ({ personProfile }) => ({
   personFirstName: personProfile.personFirstName,
   personLastName: personProfile.personLastName,
 });

--- a/src/containers/SetupScreen/index.js
+++ b/src/containers/SetupScreen/index.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { View, Keyboard } from 'react-native';
-import {translate} from 'react-i18next';
+import { translate } from 'react-i18next';
 import styles from './styles';
 import { Button, Text, PlatformKeyboardAvoidingView, Flex } from '../../components/common';
 import Input from '../../components/Input/index';
 import { navigatePush } from '../../actions/navigation';
-import {createMyPerson, firstNameChanged, lastNameChanged} from '../../actions/profile';
+import { createMyPerson, firstNameChanged, lastNameChanged } from '../../actions/profile';
 
 @translate('setup')
 class SetupScreen extends Component {
@@ -26,12 +26,12 @@ class SetupScreen extends Component {
     return (
       <PlatformKeyboardAvoidingView>
         <Flex value={1} />
-        <Flex value={2} style={{alignItems: 'center'}}>
+        <Flex value={2} style={{ alignItems: 'center' }}>
           <Text type="header" style={styles.header}>-first things first-</Text>
           <Text type="header" style={styles.headerTwo}>what's your name?</Text>
         </Flex>
 
-        <Flex value={3} style={{padding: 30}}>
+        <Flex value={3} style={{ padding: 30 }}>
           <View>
             <Text style={styles.label}>{t('profileLabels.firstNameRequired')}</Text>
             <Input
@@ -48,7 +48,7 @@ class SetupScreen extends Component {
             />
           </View>
 
-          <View style={{paddingTop: 30}}>
+          <View style={{ paddingTop: 30 }}>
             <Input
               ref={(c) => this.lastName = c}
               onChangeText={(t) => this.props.dispatch(lastNameChanged(t))}
@@ -74,7 +74,7 @@ class SetupScreen extends Component {
   }
 }
 
-const mapStateToProps = ({profile}) => ({
+const mapStateToProps = ({ profile }) => ({
   firstName: profile.firstName,
   lastName: profile.lastName,
 });

--- a/src/containers/StageScreen.js
+++ b/src/containers/StageScreen.js
@@ -1,8 +1,8 @@
-import React, {Component} from 'react';
-import {connect} from 'react-redux';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import PathwayStageScreen from './PathwayStageScreen/index';
-import {selectStage} from '../actions/selectStage';
+import { selectStage } from '../actions/selectStage';
 
 class StageScreen extends Component {
   constructor(props) {
@@ -19,7 +19,7 @@ class StageScreen extends Component {
 
 }
 
-const mapStateToProps = ({profile}) => ({
+const mapStateToProps = ({ profile }) => ({
   firstName: profile.firstName,
 });
 

--- a/src/containers/StageSuccessScreen.js
+++ b/src/containers/StageSuccessScreen.js
@@ -1,5 +1,5 @@
-import React, {Component} from 'react';
-import {connect} from 'react-redux';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import IconMessageScreen from './IconMessageScreen/index';
 
 class StageSuccessScreen extends Component {
@@ -13,7 +13,7 @@ class StageSuccessScreen extends Component {
   }
 }
 
-const mapStateToProps = ({profile}) => ({
+const mapStateToProps = ({ profile }) => ({
   firstName: profile.firstName,
 });
 

--- a/src/containers/WelcomeScreen/index.js
+++ b/src/containers/WelcomeScreen/index.js
@@ -32,7 +32,7 @@ class WelcomeScreen extends Component {
             type="secondary"
             onPress={() => this.navigateToNext()}
             text="OK"
-            style={{width: theme.fullWidth}}
+            style={{ width: theme.fullWidth }}
           />
         </Flex>
       </Flex>
@@ -40,7 +40,7 @@ class WelcomeScreen extends Component {
   }
 }
 
-const mapStateToProps = ({auth}) => ({
+const mapStateToProps = ({ auth }) => ({
   auth: auth,
 });
 

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,7 +1,7 @@
 import i18n from 'i18next';
 import { reactI18nextModule } from 'react-i18next';
 import mapValues from 'lodash/mapValues';
-import {locale} from '../utils/common';
+import { locale } from '../utils/common';
 
 import translations from './locales/translations.json';
 import en_US from './locales/en-US.js';

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,4 @@
-import {combineReducers} from 'redux';
+import { combineReducers } from 'redux';
 
 import auth from './auth';
 import nav from './nav';

--- a/src/reducers/myStage.js
+++ b/src/reducers/myStage.js
@@ -1,5 +1,5 @@
 import { REHYDRATE } from 'redux-persist/constants';
-import {REQUESTS} from '../actions/api';
+import { REQUESTS } from '../actions/api';
 import { LOGOUT } from '../constants';
 
 const initialState = {

--- a/src/reducers/nav.js
+++ b/src/reducers/nav.js
@@ -1,4 +1,4 @@
-import { NavigationActions} from 'react-navigation';
+import { NavigationActions } from 'react-navigation';
 import { REHYDRATE } from 'redux-persist/constants';
 import { MainRoutes } from '../AppRoutes';
 

--- a/src/reducers/personProfile.js
+++ b/src/reducers/personProfile.js
@@ -1,6 +1,6 @@
 import { REHYDRATE } from 'redux-persist/constants';
-import {PERSON_FIRST_NAME_CHANGED, PERSON_LAST_NAME_CHANGED} from '../constants';
-import {REQUESTS} from '../actions/api';
+import { PERSON_FIRST_NAME_CHANGED, PERSON_LAST_NAME_CHANGED } from '../constants';
+import { REQUESTS } from '../actions/api';
 
 const initialPersonProfileState = {
   personFirstName: '',

--- a/src/reducers/steps.js
+++ b/src/reducers/steps.js
@@ -33,7 +33,7 @@ function stepsReducer(state = initialState, action) {
     case REQUESTS.GET_MY_CHALLENGES.SUCCESS:
       let mySteps = action.results.findAll('accepted_challenge') || [];
       mySteps = mySteps.map((s)=> {
-        if (state.reminders.find((r)=> r.id === s.id)) return {...s, reminder: true};
+        if (state.reminders.find((r)=> r.id === s.id)) return { ...s, reminder: true };
         return s;
       });
       return {
@@ -42,7 +42,7 @@ function stepsReducer(state = initialState, action) {
       };
     case ADD_STEP_REMINDER:
       const newMine = state.mine.map((s)=> {
-        if (s.id === action.step.id) return {...s, reminder: true};
+        if (s.id === action.step.id) return { ...s, reminder: true };
         return s;
       });
       return {
@@ -52,7 +52,7 @@ function stepsReducer(state = initialState, action) {
       };
     case REMOVE_STEP_REMINDER:
       const newRemove = state.mine.map((s)=> {
-        if (s.id === action.step.id) return {...s, reminder: undefined};
+        if (s.id === action.step.id) return { ...s, reminder: undefined };
         return s;
       });
       return {


### PR DESCRIPTION
- Update yarn.lock

The inconsistent curly spacing in imports were bothering me.
`import {something} from 'someplace';`
`import { something } from 'someplace';`

This just picks the second option. I'm fine with doing `never` if that is preferable, just the inconsistency was bothering me. It is super easy to switch with eslint fix.