### PR TITLE
MHP-984: Transition from notification prompt to celebration screen

### DIFF
--- a/src/containers/NotificationPrimerScreen/index.js
+++ b/src/containers/NotificationPrimerScreen/index.js
@@ -22,7 +22,7 @@ class NotificationPrimerScreen extends Component {
   }
 
   done() {
-    this.props.dispatch(navigatePush('MainTabs'));
+    this.props.dispatch(navigatePush('Celebration'));
   }
 
   render() {


### PR DESCRIPTION
It seems a little brittle to transition at a child component level. What if the notifications component is used somewhere else or removed? I'm having a hard time wrapping my head around how one component redirects to another. Seems like we have multiple onboarding flows. I guess this is what I was trying to ask about the other day at the sprint planning meeting. Is there a better way to do control the flow in a stack nav? I could just be missing something.

It seems like this might be better handled in a reducer.

You could have a current flow set in the state and the `currentFlowStep` would tell the router which screen to show.
```
const state = {
  currentFlow: 'facebookOnboarding',
  currentFlowStep: 'notificationPrompt',
}
```

And have a reducer that handles the redirection: (my redux syntax is probably incorrect. Ignore it 😃 I haven't written anything that actually interacts with the router...)
```
// example action
const action = {
  type: 'navFlowTransition',
  direction: 'next', // or 'previous'
}

navReducer(state, action) {
  switch(state.currentFlow){
    case 'facebookOnboarding':
      return facebookOnboardingReducer(state, action);
    ...
  }
}

facebookOnboardingReducer(state, action) {
  switch(state.currentFlowStep){
    ...
    case 'notificationPrompt':
      return { ...state, ...{ currentFlowStep: action.direction === 'next' ? 'Celebration' : 'SelectSteps';
    case 'Celebration':
      // Probably also needs to change the currentFlow and reset the nav stack if we move to MainTabs
      return { ...state, ...{ currentFlowStep: action.direction === 'next' ? 'MainTabs' : 'notificationPrompt';
    ...
  }
}
```

I might be writing my own router at this point which probably isn't great... Maybe the previous direction should be handled by the stack nav to get transitions correct.

Hopefully this conveys my question/confusion. I'm not quite sure what to ask :)