### PR TITLE
MHP-1007: Fix onesky:upload command naming in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
-  yarn run oneSky:upload; fi
+  yarn run onesky:upload; fi
 cache:
   yarn: true
 env:


### PR DESCRIPTION
Apparently scripts are case sensitive and I type in camelCase lol. Oops.
https://travis-ci.com/CruGlobal/missionhub-react-native/builds/62082166#L800