### PR TITLE
Speed up jest on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '8'
 script:
-- yarn run test:coverage
+- yarn run test:coverage -- --maxWorkers=4
 - yarn run lint
 notifications:
   email: false


### PR DESCRIPTION
https://facebook.github.io/jest/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server

Even the paid plan we're on only seems to have 2 CPUs as far as I could tell. But an 8min to 3min build is a pretty good improvement :)