### PR TITLE
Mhp 1165

### DIFF
--- a/__tests__/containers/ContactSteps.js
+++ b/__tests__/containers/ContactSteps.js
@@ -68,7 +68,7 @@ describe('Navigation to steps screen', () => {
 
     expect(navigation.navigatePush).toHaveBeenCalledWith(
       SELECT_MY_STEP_SCREEN,
-      { onSaveNewSteps, enableButton: true }
+      { onSaveNewSteps, enableBackButton: true }
     );
   });
 


### PR DESCRIPTION
ContactScreen used to route to PersonSelectStepScreen, regardless of it being the personal screen or a screen for a contact.

If the ContactScreen is the personal screen for the user, it now routes to SelectMyStepScreen.

Also integrated a back button on SelectMyStepScreen that only appears after onboarding.