### PR TITLE
MHP 1130 -- Fixes from QA response

### DIFF
--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -148,6 +148,7 @@ const screens = {
       Main: { screen: MainTabRoutes },
     }, {
       contentComponent: SettingsMenu,
+      navigationOptions: { drawerLockMode: 'locked-closed' },
     }),
     stepsTab, //stepsTab is shown when MainTabs first opens
   ),
@@ -178,6 +179,7 @@ export const MainStackRoutes = StackNavigator({
       {
         contentComponent: ContactSideMenu,
         drawerPosition: 'right',
+        navigationOptions: { drawerLockMode: 'locked-closed' },
       }
     ),
     navigationOptions: { gesturesEnabled: true },


### PR DESCRIPTION
1130 focused on removing the swipe back gesture from pages that did not have a back button.

In this update, the gesture is also being removed from the side menus off of the main tab view and the contact screen.