### PR TITLE
MHP-1280: Increase limit on contact steps endpoint

### DIFF
--- a/__tests__/actions/steps.js
+++ b/__tests__/actions/steps.js
@@ -73,7 +73,7 @@ describe('getStepsByFilter', () => {
 
     store.dispatch(getStepsByFilter(stepsFilter));
 
-    expect(callApi).toHaveBeenCalledWith(REQUESTS.GET_CHALLENGES_BY_FILTER, { filters: stepsFilter, page: { limit: 100 } });
+    expect(callApi).toHaveBeenCalledWith(REQUESTS.GET_CHALLENGES_BY_FILTER, { filters: stepsFilter, page: { limit: 1000 } });
     expect(store.getActions()).toEqual([ apiResult ]);
   });
 });

--- a/src/actions/steps.js
+++ b/src/actions/steps.js
@@ -60,7 +60,7 @@ export function getStepsByFilter(filters = {}) {
   return (dispatch) => {
     const query = {
       filters,
-      page: { limit: 100 },
+      page: { limit: 1000 },
     };
     return dispatch(callApi(REQUESTS.GET_CHALLENGES_BY_FILTER, query));
   };


### PR DESCRIPTION
This still seems to be a sub 1 second request from the API with 100 items. However Reactotron is going crazy with 100 items and is blocking the UI. Disabling reactotron makes it behave fine.