### PR TITLE
Add react native config

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,7 @@
+API_BASE_URL=https://api-stage.missionhub.com
+APNS_SANDBOX=true
+GCM_SENDER_ID=208966923006
+THE_KEY_URL=https://thekey.me/cas/
+THE_KEY_CLIENT_ID=8480288430352167964
 ONESKY_API_KEY=onesky_placeholder_key
 ONESKY_SECRET_KEY=onesky_placeholder_secret

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,5 @@
+API_BASE_URL=https://api.missionhub.com
+APNS_SANDBOX=false
+GCM_SENDER_ID=208966923006
+THE_KEY_URL=https://thekey.me/cas/
+THE_KEY_CLIENT_ID=8480288430352167964

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -169,6 +169,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-config')
     compile project(':react-native-default-preference')
     compile project(':react-native-fabric')
     compile project(':react-native-fbsdk')

--- a/android/app/src/main/java/com/missionhub/MainApplication.java
+++ b/android/app/src/main/java/com/missionhub/MainApplication.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.core.CrashlyticsCore;
 import com.facebook.react.ReactApplication;
+import com.lugg.ReactNativeConfig.ReactNativeConfigPackage;
 import com.reactlibrary.RNDefaultPreferencePackage;
 import com.smixx.fabric.FabricPackage;
 import com.facebook.reactnative.androidsdk.FBSDKPackage;
@@ -47,6 +48,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new ReactNativeConfigPackage(),
             new RNDefaultPreferencePackage(),
             new FabricPackage(),
             new FBSDKPackage(mCallbackManager),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'MissionHub'
+include ':react-native-config'
+project(':react-native-config').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-config/android')
 include ':react-native-default-preference'
 project(':react-native-default-preference').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-default-preference/android')
 include ':react-native-fabric'

--- a/ios/MissionHub.xcodeproj/project.pbxproj
+++ b/ios/MissionHub.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -71,6 +70,7 @@
 		FA45FFF01FFE7E7300153E56 /* AdobeMobileLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA45FFC21FFE7D9600153E56 /* AdobeMobileLibrary.a */; };
 		FD487B586E344F67806CD6AD /* SourceSansPro-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 965575DE5A994FE09AA10EC4 /* SourceSansPro-Regular.ttf */; };
 		FEE571759377450BAF6BC4BB /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 61DE556CDA154426A57159A9 /* Entypo.ttf */; };
+		63CCD346A5A94B92885F6266 /* libReactNativeConfig.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 11EED27DCE4942CAAD01A388 /* libReactNativeConfig.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -476,6 +476,8 @@
 		FA45FFC21FFE7D9600153E56 /* AdobeMobileLibrary.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = AdobeMobileLibrary.a; sourceTree = "<group>"; };
 		FA45FFEC1FFE7DFD00153E56 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		FA45FFEE1FFE7E0900153E56 /* libsqlite3.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.0.tbd; path = usr/lib/libsqlite3.0.tbd; sourceTree = SDKROOT; };
+		3878D83B32ED4F84916EDEEE /* ReactNativeConfig.xcodeproj */ = {isa = PBXFileReference; name = "ReactNativeConfig.xcodeproj"; path = "../node_modules/react-native-config/ios/ReactNativeConfig.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		11EED27DCE4942CAAD01A388 /* libReactNativeConfig.a */ = {isa = PBXFileReference; name = "libReactNativeConfig.a"; path = "libReactNativeConfig.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -520,6 +522,7 @@
 				C7C940C71D8C44AE9616BFB5 /* libreactnativeomnitureapi.a in Frameworks */,
 				2166B1DAD6F1498199186152 /* libSMXCrashlytics.a in Frameworks */,
 				AF0D1B855E0F4D2CA94E1C7D /* libRNDefaultPreference.a in Frameworks */,
+				63CCD346A5A94B92885F6266 /* libReactNativeConfig.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -729,6 +732,7 @@
 				C91FE11509214641AE33C2E6 /* reactnativeomnitureapi.xcodeproj */,
 				5E558AFB09024F108756A4D1 /* SMXCrashlytics.xcodeproj */,
 				3C4317547AC44AB09D0EFD30 /* RNDefaultPreference.xcodeproj */,
+				3878D83B32ED4F84916EDEEE /* ReactNativeConfig.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1593,12 +1597,14 @@
 					"$(SRCROOT)/../node_modules/react-native-omniture/ios",
 					"$(SRCROOT)/../node_modules/react-native-fabric/ios/SMXCrashlytics",
 					"$(SRCROOT)/../node_modules/react-native-default-preference/ios",
+					"$(SRCROOT)/../node_modules/react-native-config/ios/ReactNativeConfig",
 				);
 				INFOPLIST_FILE = MissionHubTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1627,12 +1633,14 @@
 					"$(SRCROOT)/../node_modules/react-native-omniture/ios",
 					"$(SRCROOT)/../node_modules/react-native-fabric/ios/SMXCrashlytics",
 					"$(SRCROOT)/../node_modules/react-native-default-preference/ios",
+					"$(SRCROOT)/../node_modules/react-native-config/ios/ReactNativeConfig",
 				);
 				INFOPLIST_FILE = MissionHubTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1670,6 +1678,7 @@
 					"$(SRCROOT)/../node_modules/react-native-omniture/ios",
 					"$(SRCROOT)/../node_modules/react-native-fabric/ios/SMXCrashlytics",
 					"$(SRCROOT)/../node_modules/react-native-default-preference/ios",
+					"$(SRCROOT)/../node_modules/react-native-config/ios/ReactNativeConfig",
 				);
 				INFOPLIST_FILE = MissionHub/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1718,6 +1727,7 @@
 					"$(SRCROOT)/../node_modules/react-native-omniture/ios",
 					"$(SRCROOT)/../node_modules/react-native-fabric/ios/SMXCrashlytics",
 					"$(SRCROOT)/../node_modules/react-native-default-preference/ios",
+					"$(SRCROOT)/../node_modules/react-native-config/ios/ReactNativeConfig",
 				);
 				INFOPLIST_FILE = MissionHub/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1762,11 +1772,13 @@
 					"$(SRCROOT)/../node_modules/react-native-omniture/ios",
 					"$(SRCROOT)/../node_modules/react-native-fabric/ios/SMXCrashlytics",
 					"$(SRCROOT)/../node_modules/react-native-default-preference/ios",
+					"$(SRCROOT)/../node_modules/react-native-config/ios/ReactNativeConfig",
 				);
 				INFOPLIST_FILE = "MissionHub-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1802,11 +1814,13 @@
 					"$(SRCROOT)/../node_modules/react-native-omniture/ios",
 					"$(SRCROOT)/../node_modules/react-native-fabric/ios/SMXCrashlytics",
 					"$(SRCROOT)/../node_modules/react-native-default-preference/ios",
+					"$(SRCROOT)/../node_modules/react-native-config/ios/ReactNativeConfig",
 				);
 				INFOPLIST_FILE = "MissionHub-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1838,6 +1852,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.MissionHub-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1863,6 +1878,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.REACT.MissionHub-tvOSTests";

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"react-i18next": "7.1.1",
 		"react-native": "0.50.4",
 		"react-native-animatable": "1.2.4",
+		"react-native-config": "^0.11.5",
 		"react-native-default-preference": "1.3.1",
 		"react-native-device-info": "0.12.1",
 		"react-native-fabric": "0.5.1",

--- a/src/actions/notifications.js
+++ b/src/actions/notifications.js
@@ -1,6 +1,7 @@
 import { ToastAndroid } from 'react-native';
 import PushNotification from 'react-native-push-notification';
 import DeviceInfo from 'react-native-device-info';
+import Config from 'react-native-config';
 
 import { REQUESTS } from './api';
 import callApi from './api';
@@ -163,7 +164,9 @@ export function registerPushDevice(token) {
         type: 'push_notification_device_token',
         attributes: {
           token,
-          platform: type === 'Apple' ? 'APNS' : 'GCM',
+          platform: type === 'Apple' ?
+            Config.APNS_SANDBOX ? 'APNS_SANDBOX' : 'APNS' :
+            'GCM',
         },
       },
     };

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -1,17 +1,12 @@
 import merge from 'lodash/merge';
 import qs from 'qs';
+import Config from 'react-native-config';
 
 const API_VERSION = 'v4';
-let baseUrl = '';
-if (__DEV__) {
-  baseUrl = 'https://api-stage.missionhub.com';
-} else {
-  baseUrl = 'https://api.missionhub.com';
-}
 
-export const BASE_URL = baseUrl;
+export const BASE_URL = Config.API_BASE_URL;
 export const API_URL = `${BASE_URL}/apis/${API_VERSION}/`;
-export const THE_KEY_URL = 'https://thekey.me/cas/';
+export const THE_KEY_URL = Config.THE_KEY_URL;
 
 const DEFAULT_HEADERS = {
   Accept: 'application/json',

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
+import Config from 'react-native-config';
+
 export const LOGIN = 'app/LOGIN';
 export const LOGOUT = 'app/LOGOUT';
 export const FIRST_TIME = 'app/FIRST_TIME';
@@ -44,7 +46,7 @@ export const CONTACT_MENU_DRAWER = 'nav/drawer/contact';
 export const EXPIRED_ACCESS_TOKEN = 'Expired access token';
 
 export const URL_ENCODED = 'application/x-www-form-urlencoded';
-export const THE_KEY_CLIENT_ID = '8480288430352167964';
+export const THE_KEY_CLIENT_ID = Config.THE_KEY_CLIENT_ID;
 
 export const CASEY = 'casey';
 export const JEAN = 'jean';
@@ -60,7 +62,7 @@ export const LINKS = {
 export const ANALYTICS_CONTEXT_CHANGED = 'app/ANALYTICS_CONTEXT_CHANGED';
 
 export const ORG_PERMISSIONS = [ 1, 4 ];
-export const GCM_SENDER_ID = '208966923006';
+export const GCM_SENDER_ID = Config.GCM_SENDER_ID;
 
 export const ANALYTICS = {
   MCID: 'cru.mcid',
@@ -131,7 +133,3 @@ export const INTERACTION_TYPES = {
 };
 
 export const DEFAULT_PAGE_LIMIT = 25;
-
-export default {
-
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4393,6 +4393,10 @@ react-native-animatable@1.2.4:
   dependencies:
     prop-types "^15.5.10"
 
+react-native-config@^0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-0.11.5.tgz#516cb7b6ec437c7739236ca075971db3aabdcb95"
+
 react-native-default-preference@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-native-default-preference/-/react-native-default-preference-1.3.1.tgz#5eeb415bdc71334e39d7837a0399dee1169a832e"


### PR DESCRIPTION
@dsgoers Could we talk at some point about how the analytics environment switching works? Idk if this library can handle it.

If we only end up using this for JS env variables and don't need to do anything specific in iOS or Android, we could just use [`dotenv`](https://github.com/motdotla/dotenv) which is already in the project for the OneSky scripts (it discourages multiple ENV files but we could probably make that work or use normal ENV variables or something on the command line) or [`react-native-dotenv`](https://github.com/zetachang/react-native-dotenv) which is a babel plugin and seems like it could switch to production automatically with a release build.