### PR TITLE
Fix org name undefined when doing localeCompare

### DIFF
--- a/__tests__/reducers/__snapshots__/people.js.snap
+++ b/__tests__/reducers/__snapshots__/people.js.snap
@@ -53,6 +53,7 @@ Object {
   },
   "105": Object {
     "id": "105",
+    "name": "",
     "people": Object {
       "2": Object {
         "first_name": "Test Person",
@@ -119,6 +120,7 @@ Object {
   },
   "personal": Object {
     "id": "personal",
+    "name": "",
     "people": Object {
       "2": Object {
         "first_name": "Test Person",

--- a/src/reducers/people.js
+++ b/src/reducers/people.js
@@ -28,6 +28,7 @@ export default function peopleReducer(state = initialState, action) {
           ...updateAllPersonInstances(state.allByOrg, action.person, true), // update existing people
           [ orgId ]: { // make sure person is added to specified org or create the org if it doesn't exist
             id: orgId,
+            name: '', // Used for sorting in the peopleByOrgSelector, called by the People Tab. The People Tab should reload this and get the full org
             ...currentOrg,
             people: {
               ...currentOrg ? currentOrg.people : {},

--- a/src/selectors/people.js
+++ b/src/selectors/people.js
@@ -26,7 +26,7 @@ export const peopleByOrgSelector = createSelector(
       if (b.id === 'personal') {
         return 1;
       }
-      return (a.name || a.id).localeCompare((b.name || b.id));
+      return a.name.localeCompare(b.name);
     })
 );
 export const personSelector = createSelector(


### PR DESCRIPTION
I guess this is related to what we were talking about.

Clicking a step goes to the contact screen which loads the person's details without the org name. Then the person tab is unable to sort that org and throws a red error because it doesn't reload orgs with names before trying to render.

I found this when impersonating Alex although I imagine it happens wherever you do this. I could do something other than using the id as the sort key... Seems like we should probably just include the org when loading person details and store it in the allByOrg org. Idk if you have a ticket for any of that or are working on it. It might be fixed by MHP-1269 if you go that route with that ticket.