### PR TITLE
Remove Axios dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"onesky:download": "babel-node ./bin/oneskyDownload.js"
 	},
 	"dependencies": {
-		"axios": "0.17.0",
 		"babel-plugin-transform-decorators-legacy": "1.3.4",
 		"base64-url": "2.2.0",
 		"buffer": "5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,13 +269,6 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-axios@0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.0.tgz#7da747916db803f761651d6091d708789b953c6a"
-  dependencies:
-    follow-redirects "^1.2.3"
-    is-buffer "^1.1.5"
-
 babel-cli@6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
@@ -1558,7 +1551,7 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -2202,12 +2195,6 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
-
-follow-redirects@^1.2.3:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.2.5.tgz#ffd3e14cbdd5eaa72f61b6368c1f68516c2a26cc"
-  dependencies:
-    debug "^2.6.9"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
I don't see this used. Seems like we're using fetch everywhere. I did notice https://github.com/CruGlobal/missionhub-react-native/commit/220c4128febfa77c8b94c4a0e9aa46008b671082 added it but it doesn't seem to be used there anymore.

If I'm missing something, let me know. I was just looking through the app to see what we are actually doing with the API. I'm thinking about the offline stuff.