### PR TITLE
Add Android vibrate permission for notifications

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,15 +1,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.missionhub"
-    android:versionCode="1"
-    android:versionName="1.0">
+          package="com.missionhub"
+          android:versionCode="1"
+          android:versionName="1.0">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <!-- Permissions for react-native-push-notification -->
     <permission
         android:name="${applicationId}.permission.C2D_MESSAGE"
         android:protectionLevel="signature" />
     <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
-    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <!-- End permissions for react-native-push-notification -->
 
     <uses-sdk
         android:minSdkVersion="16"
@@ -23,33 +26,34 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme">
 
-    <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id" />
+        <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id" />
 
-      <activity
-        android:name=".MainActivity"
-        android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:screenOrientation="portrait"
-        android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
+        <activity
+            android:name=".MainActivity"
+            android:label="@string/app_name"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:screenOrientation="portrait"
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
 
-        <intent-filter android:autoVerify="true">
-          <action android:name="android.intent.action.VIEW" />
-          <category android:name="android.intent.category.DEFAULT" />
-          <category android:name="android.intent.category.BROWSABLE" />
-          <data android:host="missionhub.com" />
-          <data android:pathPrefix="/auth" />
-          <data android:scheme="http" />
-          <data android:scheme="https" />
-        </intent-filter>
-      </activity>
-      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:host="missionhub.com" />
+                <data android:pathPrefix="/auth" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+            </intent-filter>
+        </activity>
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 
-      <receiver
+        <!-- Config for react-native-push-notification -->
+        <receiver
             android:name="com.google.android.gms.gcm.GcmReceiver"
             android:exported="true"
             android:permission="com.google.android.c2dm.permission.SEND" >
@@ -66,12 +70,6 @@
             </intent-filter>
         </receiver>
 
-        <receiver android:name="com.missionhub.GPBroadcastReceiver" android:exported="true">
-          <intent-filter>
-            <action android:name="com.android.vending.INSTALL_REFERRER" />
-          </intent-filter>
-        </receiver>
-
         <service android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationRegistrationService"/>
         <service
             android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationListenerService"
@@ -80,6 +78,13 @@
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
             </intent-filter>
         </service>
+        <!-- End config for react-native-push-notification -->
+
+        <receiver android:name="com.missionhub.GPBroadcastReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="com.android.vending.INSTALL_REFERRER" />
+            </intent-filter>
+        </receiver>
 
         <meta-data
             android:name="io.fabric.ApiKey"


### PR DESCRIPTION
I was looking at the docs for https://github.com/zo0r/react-native-push-notification#android-manual-installation and noticed it was the library that added the extra permissions I removed.

It also had these other 2 permissions. I'm not sure if the wake lock is needed but restoring notifications after a reboot might be good to do. (I linked these mainly for the commit messages)
https://github.com/zo0r/react-native-push-notification/commit/42fc82e36573feba6c5aca941350e82375cef633
https://github.com/zo0r/react-native-push-notification/commit/83c300d95b21fd986fabfdefd8ea04899f86330a#diff-04c6e90faac2675aa89e2176d2eec7d8R50

I guess these aren't too important but if you have time to take a quick look sometime and see what we should add back, that would be helpful. Thanks :)

The only reason for needing wake lock that I can think of is for keeping the app awake long enough to turn a silent notification into a local notification. You can see my comment 
 on https://jira.cru.org/browse/MHP-1395?focusedCommentId=63418&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-63418.