### PR TITLE
MHP 1275 -- Design Updates to Loading Wheel on Login Screens

### DIFF
--- a/__tests__/containers/__snapshots__/KeyLoginScreen.js.snap
+++ b/__tests__/containers/__snapshots__/KeyLoginScreen.js.snap
@@ -173,17 +173,8 @@ exports[`a login button is clicked facebook login button is pressed loading whee
         </MyText>
       </Flex>
     </Button>
-    <Flex
-      style={
-        Object {
-          "justifyContent": "center",
-        }
-      }
-      value={1}
-    >
-      <LoadingWheel />
-    </Flex>
   </Flex>
+  <LoadingWheel />
 </PlatformKeyboardAvoidingView>
 `;
 
@@ -360,17 +351,8 @@ exports[`a login button is clicked forgot password button is pressed loading whe
         </MyText>
       </Flex>
     </Button>
-    <Flex
-      style={
-        Object {
-          "justifyContent": "center",
-        }
-      }
-      value={1}
-    >
-      <LoadingWheel />
-    </Flex>
   </Flex>
+  <LoadingWheel />
 </PlatformKeyboardAvoidingView>
 `;
 
@@ -492,16 +474,6 @@ exports[`a login button is clicked key login button is pressed loading wheel app
         type="transparent"
       />
     </View>
-    <Flex
-      style={
-        Object {
-          "justifyContent": "center",
-        }
-      }
-      value={1}
-    >
-      <LoadingWheel />
-    </Flex>
   </Flex>
   <Flex
     align="stretch"
@@ -514,6 +486,7 @@ exports[`a login button is clicked key login button is pressed loading wheel app
       type="secondary"
     />
   </Flex>
+  <LoadingWheel />
 </PlatformKeyboardAvoidingView>
 `;
 

--- a/__tests__/containers/__snapshots__/LoginOptionsScreen.js.snap
+++ b/__tests__/containers/__snapshots__/LoginOptionsScreen.js.snap
@@ -255,17 +255,6 @@ exports[`a login button is clicked email signup button is pressed loading wheel 
             />
           </Flex>
         </Flex>
-        <Flex
-          style={
-            Object {
-              "justifyContent": "center",
-              "width": 2,
-            }
-          }
-          value={1}
-        >
-          <LoadingWheel />
-        </Flex>
       </Flex>
       <Flex
         align="end"
@@ -309,6 +298,7 @@ exports[`a login button is clicked email signup button is pressed loading wheel 
       </Flex>
     </Flex>
   </Flex>
+  <LoadingWheel />
 </Flex>
 `;
 
@@ -567,17 +557,6 @@ exports[`a login button is clicked facebook signup button is pressed loading whe
             />
           </Flex>
         </Flex>
-        <Flex
-          style={
-            Object {
-              "justifyContent": "center",
-              "width": 2,
-            }
-          }
-          value={1}
-        >
-          <LoadingWheel />
-        </Flex>
       </Flex>
       <Flex
         align="end"
@@ -621,6 +600,7 @@ exports[`a login button is clicked facebook signup button is pressed loading whe
       </Flex>
     </Flex>
   </Flex>
+  <LoadingWheel />
 </Flex>
 `;
 

--- a/src/components/LoadingWheel/index.js
+++ b/src/components/LoadingWheel/index.js
@@ -6,7 +6,7 @@ import styles from './styles';
 export default class LoadingWheel extends Component {
   render() {
     return (
-      <Flex value={1} align="center" justify="center" >
+      <Flex value={1} align="center" justify="center" style={styles.container}>
         <Image source={require('../../../assets/gifs/loadingSpiralBlue.gif')} resizeMode="contain" style={styles.gif} />
       </Flex>
     );

--- a/src/components/LoadingWheel/styles.js
+++ b/src/components/LoadingWheel/styles.js
@@ -1,6 +1,14 @@
 import { StyleSheet } from 'react-native';
+import theme from '../../theme';
 
 export default StyleSheet.create({
+  container: {
+    backgroundColor: theme.black,
+    position: 'absolute',
+    width: theme.fullWidth,
+    height: theme.fullHeight,
+    opacity: .75,
+  },
   gif: {
     flex: 1,
     width: 60,

--- a/src/containers/KeyLoginScreen/index.js
+++ b/src/containers/KeyLoginScreen/index.js
@@ -120,14 +120,6 @@ class KeyLoginScreen extends Component {
     );
   }
 
-  renderLoading() {
-    return (
-      <Flex value={1} style={{ justifyContent: 'center' }}>
-        <LoadingWheel />
-      </Flex>
-    );
-  }
-
   render() {
     const { t, dispatch } = this.props;
 
@@ -207,7 +199,6 @@ class KeyLoginScreen extends Component {
               </Button>
             ) : null
           }
-          {this.state.isLoading ? this.renderLoading() : null }
         </Flex>
 
         {
@@ -222,7 +213,7 @@ class KeyLoginScreen extends Component {
             </Flex>
           )
         }
-
+        {this.state.isLoading ? <LoadingWheel /> : null }
       </PlatformKeyboardAvoidingView>
     );
   }

--- a/src/containers/LoginOptionsScreen/index.js
+++ b/src/containers/LoginOptionsScreen/index.js
@@ -66,14 +66,6 @@ class LoginOptionsScreen extends Component {
     });
   };
 
-  renderLoading() {
-    return (
-      <Flex value={1} style={{ justifyContent: 'center', width: 2 }}>
-        <LoadingWheel />
-      </Flex>
-    );
-  }
-
   render() {
     const { t, upgradeAccount } = this.props;
 
@@ -139,7 +131,7 @@ class LoginOptionsScreen extends Component {
                   />
                 </Flex>
               </Flex>
-              {this.state.isLoading ? this.renderLoading() : null }
+
             </Flex>
 
             <Flex value={1} align="end" direction="row">
@@ -154,6 +146,7 @@ class LoginOptionsScreen extends Component {
             </Flex>
           </Flex>
         </Flex>
+        {this.state.isLoading ? <LoadingWheel /> : null }
       </Flex>
     );
   }


### PR DESCRIPTION
Eric and I discussed a different way of displaying the loading wheel on LoginOptionsScreen and KeyLoginScreen.  This should be triggered in a few different cases:

- returning from sign up with Facebook (LoginOptions)
- returning from sign up with email (LoginOptions)
- returning from the "forgot password" flow (KeyLogin)
- returning from sign in with Facebook (KeyLogin)
- Selecting the "login" button after entering email and password (KeyLogin)