### PR TITLE
MHP-1290 add current year period

### DIFF
--- a/src/containers/ImpactView/index.js
+++ b/src/containers/ImpactView/index.js
@@ -71,7 +71,7 @@ export class ImpactView extends Component {
     var months = today.getMonth();
     var days = today.getDate();
 
-    return 'P' + months + 'M' + days + 'D';
+    return `P${months}M${days}D`;
   };
 
   async getInteractionReport(period = this.state.period) {


### PR DESCRIPTION
Add a period that roughly tracks the current year.

The interactions report needs a period, while the other two reports called for the user's impact are automatically scoped to the current year

I say "roughly" because it's not an exact calcuation. In my testing the start date was actually 12-29-2017 instead of 1-1-2018. This would mean that interactions done in the last three days of the previous year would affect the numbers shown.. but maybe this is close enough for horseshoes?