### PR TITLE
Let fastlane generate profiles

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -128,7 +128,7 @@ platform :ios do
           add_to_search_list: true
       )
 
-      match(readonly: true,
+      match(readonly: false,
             type: options[:type],
             keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
             keychain_password: ENV["MATCH_PASSWORD"])


### PR DESCRIPTION
Occasionally profiles will get nuked and recreated to add new devices. Match can handle this, if we let it.