### PR TITLE
Merge 2 levels deep on rehydrate since we have nested reducers

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -2,6 +2,7 @@ import { AsyncStorage } from 'react-native';
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import { persistStore, persistReducer, createTransform } from 'redux-persist';
+import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 import getStoredStateMigrateV4 from 'redux-persist/lib/integration/getStoredStateMigrateV4';
 import jsan from 'jsan';
 import { createReactNavigationReduxMiddleware } from 'react-navigation-redux-helpers';
@@ -40,6 +41,7 @@ let myTransform = createTransform(
 const persistConfig = {
   key: 'root',
   storage: AsyncStorage,
+  stateReconciler: autoMergeLevel2,
   transforms: [ myTransform ],
   getStoredState: getStoredStateMigrateV4({ storage: AsyncStorage, transforms: [ myTransform ] }),
 };


### PR DESCRIPTION
Without this, there are issues with state variables being undefined due to the fact that our reducers are nested (`{ auth: { token: '123' } }` instead of just `{ auth_token: '123' }`).

I'm refactoring the ImpactView and added a new key to the impact `initialState` and it wasn't picked up until I added this. I could see there being issues with my `auth.person.id` refactor.

I think this needs to be merged before we do a release. I'll comment in the room asking about the state of the release.

Here are the docs for this: https://github.com/rt2zz/redux-persist#state-reconciler