### PR TITLE
Revert "MHP-1323 -- Change Android build settings to reduce file size"

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -103,7 +103,7 @@ repositories {
  * Upload all the APKs to the Play Store and people will download
  * the correct one based on the CPU architecture of their device.
  */
-def enableSeparateBuildPerCPUArchitecture = true
+def enableSeparateBuildPerCPUArchitecture = false
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.


### PR DESCRIPTION
Reverts CruGlobal/missionhub-react-native#356. This was preventing downloads Crashlytics builds on Android.