### PR TITLE
Mhp 1484 quick fix

### DIFF
--- a/src/containers/SelectStepScreen/index.js
+++ b/src/containers/SelectStepScreen/index.js
@@ -77,20 +77,20 @@ class SelectStepScreen extends Component {
       return;
     }
 
-    let newIndex = suggestionIndex + 4;
-    if (newIndex > suggestions.length) {
-      newIndex = suggestions.length;
+    let suggestionIndexMax = suggestionIndex + 4;
+    if (suggestionIndexMax > suggestions.length) {
+      suggestionIndexMax = suggestions.length;
     }
 
-    let newSuggestions = suggestions.slice(0, newIndex);
+    let newSuggestions = suggestions.slice(suggestionIndex, suggestionIndexMax);
 
     if (!isMe) {
       newSuggestions = this.insertName(newSuggestions);
     }
 
     this.setState({
-      steps: [...newSuggestions, ...this.state.addedSteps],
-      suggestionIndex: newIndex,
+      steps: [...this.state.steps, ...newSuggestions],
+      suggestionIndex: suggestionIndexMax,
     });
   };
 


### PR DESCRIPTION
I found a new issue after this was merged.  Essentially when loading new suggestions, we tag the user's created steps to the bottom of this.state.steps.  However, they are already in the previous iteration of this.state.steps, so now they are in the list twice.

The quickest fix I could think of is to not add created steps each time, but let the new suggestions populate below them.  I'm not sure if this is what Matt and Eric are looking for, however I will check with them soon.