### PR TITLE
1597 -- Move landscape image behind carousel

### DIFF
--- a/__tests__/containers/__snapshots__/PathwayStageScreen.js.snap
+++ b/__tests__/containers/__snapshots__/PathwayStageScreen.js.snap
@@ -16,6 +16,27 @@ exports[`renders back button correctly 1`] = `
     ]
   }
 >
+  <Image
+    resizeMode="contain"
+    source={
+      Object {
+        "testUri": "../../../assets/images/landscapeStagesImage.png",
+      }
+    }
+    style={
+      Array [
+        Object {
+          "bottom": -20,
+          "height": 340.875,
+          "position": "absolute",
+          "width": 3710,
+        },
+        Object {
+          "left": -120,
+        },
+      ]
+    }
+  />
   <View
     style={
       Array [
@@ -679,6 +700,25 @@ exports[`renders back button correctly 1`] = `
       </View>
     </View>
   </RCTScrollView>
+</View>
+`;
+
+exports[`renders correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#66D9F0",
+        "flex": 1,
+      },
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
+      },
+    ]
+  }
+>
   <Image
     resizeMode="contain"
     source={
@@ -700,25 +740,6 @@ exports[`renders back button correctly 1`] = `
       ]
     }
   />
-</View>
-`;
-
-exports[`renders correctly 1`] = `
-<View
-  style={
-    Array [
-      Object {
-        "backgroundColor": "#66D9F0",
-        "flex": 1,
-      },
-      Object {
-        "alignItems": "center",
-        "flex": 1,
-        "justifyContent": "center",
-      },
-    ]
-  }
->
   <Text
     accessible={true}
     allowFontScaling={true}
@@ -1289,6 +1310,25 @@ exports[`renders correctly 1`] = `
       </View>
     </View>
   </RCTScrollView>
+</View>
+`;
+
+exports[`renders correctly without stages 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#66D9F0",
+        "flex": 1,
+      },
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
+      },
+    ]
+  }
+>
   <Image
     resizeMode="contain"
     source={
@@ -1310,25 +1350,6 @@ exports[`renders correctly 1`] = `
       ]
     }
   />
-</View>
-`;
-
-exports[`renders correctly without stages 1`] = `
-<View
-  style={
-    Array [
-      Object {
-        "backgroundColor": "#66D9F0",
-        "flex": 1,
-      },
-      Object {
-        "alignItems": "center",
-        "flex": 1,
-        "justifyContent": "center",
-      },
-    ]
-  }
->
   <Text
     accessible={true}
     allowFontScaling={true}
@@ -1355,6 +1376,25 @@ exports[`renders correctly without stages 1`] = `
       ]
     }
   />
+</View>
+`;
+
+exports[`renders firstItem correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#66D9F0",
+        "flex": 1,
+      },
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
+      },
+    ]
+  }
+>
   <Image
     resizeMode="contain"
     source={
@@ -1376,25 +1416,6 @@ exports[`renders correctly without stages 1`] = `
       ]
     }
   />
-</View>
-`;
-
-exports[`renders firstItem correctly 1`] = `
-<View
-  style={
-    Array [
-      Object {
-        "backgroundColor": "#66D9F0",
-        "flex": 1,
-      },
-      Object {
-        "alignItems": "center",
-        "flex": 1,
-        "justifyContent": "center",
-      },
-    ]
-  }
->
   <Text
     accessible={true}
     allowFontScaling={true}
@@ -1965,26 +1986,5 @@ exports[`renders firstItem correctly 1`] = `
       </View>
     </View>
   </RCTScrollView>
-  <Image
-    resizeMode="contain"
-    source={
-      Object {
-        "testUri": "../../../assets/images/landscapeStagesImage.png",
-      }
-    }
-    style={
-      Array [
-        Object {
-          "bottom": -20,
-          "height": 340.875,
-          "position": "absolute",
-          "width": 3710,
-        },
-        Object {
-          "left": -120,
-        },
-      ]
-    }
-  />
 </View>
 `;

--- a/__tests__/containers/__snapshots__/PersonStageScreen.js.snap
+++ b/__tests__/containers/__snapshots__/PersonStageScreen.js.snap
@@ -16,6 +16,27 @@ exports[`renders correctly 1`] = `
     ]
   }
 >
+  <Image
+    resizeMode="contain"
+    source={
+      Object {
+        "testUri": "../../../assets/images/landscapeStagesImage.png",
+      }
+    }
+    style={
+      Array [
+        Object {
+          "bottom": -20,
+          "height": 340.875,
+          "position": "absolute",
+          "width": 3710,
+        },
+        Object {
+          "left": -120,
+        },
+      ]
+    }
+  />
   <View
     style={
       Array [
@@ -137,26 +158,5 @@ exports[`renders correctly 1`] = `
   >
     Which stage best describes where Test is on their journey?
   </Text>
-  <Image
-    resizeMode="contain"
-    source={
-      Object {
-        "testUri": "../../../assets/images/landscapeStagesImage.png",
-      }
-    }
-    style={
-      Array [
-        Object {
-          "bottom": -20,
-          "height": 340.875,
-          "position": "absolute",
-          "width": 3710,
-        },
-        Object {
-          "left": -120,
-        },
-      ]
-    }
-  />
 </View>
 `;

--- a/__tests__/containers/__snapshots__/StageScreen.js.snap
+++ b/__tests__/containers/__snapshots__/StageScreen.js.snap
@@ -16,6 +16,27 @@ exports[`StageScreen renders correctly with back button 1`] = `
     ]
   }
 >
+  <Image
+    resizeMode="contain"
+    source={
+      Object {
+        "testUri": "../../../assets/images/landscapeStagesImage.png",
+      }
+    }
+    style={
+      Array [
+        Object {
+          "bottom": -20,
+          "height": 340.875,
+          "position": "absolute",
+          "width": 3710,
+        },
+        Object {
+          "left": -120,
+        },
+      ]
+    }
+  />
   <View
     style={
       Array [
@@ -137,6 +158,25 @@ exports[`StageScreen renders correctly with back button 1`] = `
   >
     Roger, which stage best describes where you are on your journey?
   </Text>
+</View>
+`;
+
+exports[`StageScreen renders correctly without back button 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#66D9F0",
+        "flex": 1,
+      },
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "justifyContent": "center",
+      },
+    ]
+  }
+>
   <Image
     resizeMode="contain"
     source={
@@ -158,25 +198,6 @@ exports[`StageScreen renders correctly with back button 1`] = `
       ]
     }
   />
-</View>
-`;
-
-exports[`StageScreen renders correctly without back button 1`] = `
-<View
-  style={
-    Array [
-      Object {
-        "backgroundColor": "#66D9F0",
-        "flex": 1,
-      },
-      Object {
-        "alignItems": "center",
-        "flex": 1,
-        "justifyContent": "center",
-      },
-    ]
-  }
->
   <Text
     accessible={true}
     allowFontScaling={true}
@@ -205,26 +226,5 @@ exports[`StageScreen renders correctly without back button 1`] = `
   >
     Roger, which stage best describes where you are on your journey?
   </Text>
-  <Image
-    resizeMode="contain"
-    source={
-      Object {
-        "testUri": "../../../assets/images/landscapeStagesImage.png",
-      }
-    }
-    style={
-      Array [
-        Object {
-          "bottom": -20,
-          "height": 340.875,
-          "position": "absolute",
-          "width": 3710,
-        },
-        Object {
-          "left": -120,
-        },
-      ]
-    }
-  />
 </View>
 `;

--- a/src/containers/PathwayStageScreen/index.js
+++ b/src/containers/PathwayStageScreen/index.js
@@ -129,6 +129,11 @@ class PathwayStageScreen extends Component {
 
     return (
       <Flex align="center" justify="center" value={1} style={styles.container}>
+        <Image
+          resizeMode="contain"
+          source={LANDSCAPE}
+          style={[styles.footerImage, { left: leftMargin }]}
+        />
         {this.props.enableBackButton ? <BackButton absolute={true} /> : null}
         <Text style={styles.title}>{this.props.questionText}</Text>
         {this.props.stages ? (
@@ -146,11 +151,6 @@ class PathwayStageScreen extends Component {
             containerCustomStyle={{ height: 400, flex: 0, flexGrow: 0 }}
           />
         ) : null}
-        <Image
-          resizeMode="contain"
-          source={LANDSCAPE}
-          style={[styles.footerImage, { left: leftMargin }]}
-        />
       </Flex>
     );
   }


### PR DESCRIPTION
The issue: on small screens (like iPhone 5s), the landscape image along the bottom of the pathway stage screen covers the buttons on the stage cards, and users cannot select them.

The solution: the image already has absolute positioning, so I just placed it higher on the render ordering so that the cards will be rendered on top of the image as opposed to the other way around.