### PR TITLE
filter by descendants

### DIFF
--- a/__tests__/actions/organizations.js
+++ b/__tests__/actions/organizations.js
@@ -32,6 +32,9 @@ describe('getMyOrganizations', () => {
   const query = {
     limit: 100,
     include: '',
+    filters: {
+      descendants: false,
+    },
   };
   const org1 = { id: '1' };
   const org2 = { id: '2' };

--- a/src/actions/organizations.js
+++ b/src/actions/organizations.js
@@ -10,6 +10,9 @@ import callApi, { REQUESTS } from './api';
 const getOrganizationsQuery = {
   limit: 100,
   include: '',
+  filters: {
+    descendants: false,
+  },
 };
 
 export function getMyOrganizations() {


### PR DESCRIPTION
The organizations endpoint uses pagination, meaning that on mobile we only see the first 25 or so orgs.  We decided was to add an API filter for descendants.  If filters[descendants]=false, then the endpoint will only retrieve organizations that you have explicit access to.  This shrinks the orgs list considerably, and meets the business requirements for most users.