### PR TITLE
Don't filter out Personal ministry in person selector

### DIFF
--- a/src/selectors/people.js
+++ b/src/selectors/people.js
@@ -26,7 +26,7 @@ export const peopleByOrgSelector = createSelector(
             );
           }),
       }))
-      .filter(o => o.people && o.people.length > 0),
+      .filter(o => o.people && (o.id === 'personal' || o.people.length > 0)),
 );
 
 const isAssignedToMeInOrganization = (person, org, appUserPerson) => {


### PR DESCRIPTION
This caused a crash within the render method of PeopleList since the ME person hadn't been loaded yet from the server.  A better solution might be to add the ME person to the People state in Redux during onboarding.

To reproduce, simply use the Try-it-Now flow and complete onboarding.  The first time, and only the first time, you click on the People tab, the app will crash.