### PR TITLE
MHP-1963 -- handle case where organization is null

### DIFF
--- a/src/actions/selectStage.js
+++ b/src/actions/selectStage.js
@@ -34,10 +34,9 @@ export function updateUserStage(contactAssignmentId, stageId) {
     const { response } = await dispatch(
       callApi(REQUESTS.UPDATE_CONTACT_ASSIGNMENT, query, data),
     );
-    const {
-      person: { id: personId },
-      organization: { id: orgId },
-    } = response;
+    const { person, organization } = response;
+    const personId = person && person.id;
+    const orgId = organization && organization.id;
 
     dispatch(refreshImpact());
     dispatch(getPersonDetails(personId, orgId));


### PR DESCRIPTION
This was breaking functionality on the PersonStageScreen in onboarding.  Currently, if a contact assignment has no organization, the API returns null for organization.