### PR TITLE
MHP-1986 - ensure orgPermission is not empty

### DIFF
--- a/src/actions/person.js
+++ b/src/actions/person.js
@@ -198,7 +198,7 @@ export function updatePerson(data) {
                     },
                   ]
                 : []),
-              ...(data.orgPermission
+              ...(data.orgPermission && data.orgPermission.permission_id
                 ? [
                     {
                       type: 'organizational_permission',


### PR DESCRIPTION
In Personal Ministry, an error would be thrown when attempting to send an UPDATE_PERSON API request.

The issue was that if the contact has no organizational_permissions, AddContactFilters defaults the orgPermission property to an empty array.  When this got passed to the updatePerson method, the method includes the orgPermission to the query.  The simple fix was to check not only that orgPermission existed, but that orgPermission.permission_id existed and the object is not empty.