### PR TITLE
MHP 2010 -- remove # assigned for user created org members

### DIFF
--- a/__tests__/components/GroupMemberItem.js
+++ b/__tests__/components/GroupMemberItem.js
@@ -13,7 +13,11 @@ const member = {
 describe('with onSelect prop', () => {
   it('render member', () => {
     testSnapshotShallow(
-      <GroupMemberItem onSelect={jest.fn()} person={member} />,
+      <GroupMemberItem
+        onSelect={jest.fn()}
+        person={member}
+        isUserCreatedOrg={false}
+      />,
     );
   });
 
@@ -22,6 +26,7 @@ describe('with onSelect prop', () => {
       <GroupMemberItem
         onSelect={jest.fn()}
         person={{ ...member, contact_count: 0 }}
+        isUserCreatedOrg={false}
       />,
     );
   });
@@ -31,6 +36,17 @@ describe('with onSelect prop', () => {
       <GroupMemberItem
         onSelect={jest.fn()}
         person={{ ...member, uncontacted_count: 0 }}
+        isUserCreatedOrg={false}
+      />,
+    );
+  });
+
+  it('render for user created org', () => {
+    testSnapshotShallow(
+      <GroupMemberItem
+        onSelect={jest.fn()}
+        person={member}
+        isUserCreatedOrg={true}
       />,
     );
   });

--- a/__tests__/components/__snapshots__/GroupMemberItem.js.snap
+++ b/__tests__/components/__snapshots__/GroupMemberItem.js.snap
@@ -148,6 +148,43 @@ exports[`with onSelect prop render 0 uncontacted 1`] = `
 </TouchableIOS>
 `;
 
+exports[`with onSelect prop render for user created org 1`] = `
+<TouchableIOS
+  highlight={true}
+  onPress={[Function]}
+>
+  <Flex
+    justify="center"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+        "borderBottomColor": "#E6E8EC",
+        "borderBottomWidth": 1,
+        "paddingLeft": 24,
+        "paddingRight": 13,
+        "paddingVertical": 16,
+        "width": 750,
+      }
+    }
+  >
+    <MyText
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "#007398",
+          "fontSize": 16,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      FULL NAME
+    </MyText>
+  </Flex>
+</TouchableIOS>
+`;
+
 exports[`with onSelect prop render member 1`] = `
 <TouchableIOS
   highlight={true}

--- a/__tests__/containers/Groups/__snapshots__/Members.js.snap
+++ b/__tests__/containers/Groups/__snapshots__/Members.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Members calls render item 1`] = `
 <Translate(GroupMemberItem)
+  isUserCreatedOrg={undefined}
   onSelect={[Function]}
   person={
     Object {

--- a/src/components/GroupMemberItem/index.js
+++ b/src/components/GroupMemberItem/index.js
@@ -11,24 +11,26 @@ export default class GroupMemberItem extends Component {
   handleSelect = () => this.props.onSelect(this.props.person);
 
   renderContent() {
-    const { person, t } = this.props;
+    const { person, t, isUserCreatedOrg } = this.props;
 
     return (
       <Flex justify="center" style={styles.row}>
         <Text style={styles.name}>{person.full_name.toUpperCase()}</Text>
-        <Flex align="center" direction="row" style={styles.detailsWrap}>
-          <Text style={styles.assigned}>
-            {t('numAssigned', { number: person.contact_count || 0 })}
-          </Text>
-          {person.uncontacted_count ? (
-            <Fragment>
-              <Text style={styles.assigned}>{'  ·  '}</Text>
-              <Text style={styles.uncontacted}>
-                {t('numUncontacted', { number: person.uncontacted_count })}
-              </Text>
-            </Fragment>
-          ) : null}
-        </Flex>
+        {!isUserCreatedOrg ? (
+          <Flex align="center" direction="row" style={styles.detailsWrap}>
+            <Text style={styles.assigned}>
+              {t('numAssigned', { number: person.contact_count || 0 })}
+            </Text>
+            {person.uncontacted_count ? (
+              <Fragment>
+                <Text style={styles.assigned}>{'  ·  '}</Text>
+                <Text style={styles.uncontacted}>
+                  {t('numUncontacted', { number: person.uncontacted_count })}
+                </Text>
+              </Fragment>
+            ) : null}
+          </Flex>
+        ) : null}
       </Flex>
     );
   }
@@ -54,4 +56,5 @@ GroupMemberItem.propTypes = {
     uncontacted_count: PropTypes.number,
   }).isRequired,
   onSelect: PropTypes.func,
+  isUserCreatedOrg: PropTypes.bool,
 };

--- a/src/containers/Groups/Members.js
+++ b/src/containers/Groups/Members.js
@@ -71,9 +71,16 @@ class Members extends Component {
     );
   };
 
-  renderItem = ({ item }) => (
-    <GroupMemberItem person={item} onSelect={this.handleSelect} />
-  );
+  renderItem = ({ item }) => {
+    const { organization } = this.props;
+    return (
+      <GroupMemberItem
+        isUserCreatedOrg={organization.user_created}
+        person={item}
+        onSelect={this.handleSelect}
+      />
+    );
+  };
 
   renderHeader = () => <OnboardingCard type={GROUP_ONBOARDING_TYPES.members} />;
 


### PR DESCRIPTION
Based on feedback from user testing

remove the "# assigned" count below each member on the Members tab for a user created org.  It does not make sense in that context.