### PR TITLE
MHP-2031 - Remove Challenges Tab from Cru Communities

### DIFF
--- a/__tests__/containers/Groups/GroupScreen.js
+++ b/__tests__/containers/Groups/GroupScreen.js
@@ -1,6 +1,10 @@
 import React from 'react';
 
-import { GroupScreen } from '../../../src/containers/Groups/GroupScreen';
+import {
+  GroupScreen,
+  CRU_TABS,
+  USER_CREATED_TABS,
+} from '../../../src/containers/Groups/GroupScreen';
 import {
   testSnapshotShallow,
   createMockNavState,
@@ -32,6 +36,14 @@ describe('GroupScreen', () => {
 
   it('should render header correctly for user_created org', () => {
     testSnapshotShallow(createHeader({ ...organization, user_created: true }));
+  });
+
+  it('should render Cru Community tabs correctly', () => {
+    expect(CRU_TABS).toMatchSnapshot();
+  });
+
+  it('should render User Created Community tabs correctly', () => {
+    expect(USER_CREATED_TABS).toMatchSnapshot();
   });
 
   it('should handle add contact button correctly', () => {

--- a/__tests__/containers/Groups/__snapshots__/GroupScreen.js.snap
+++ b/__tests__/containers/Groups/__snapshots__/GroupScreen.js.snap
@@ -1,5 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GroupScreen should render Cru Community tabs correctly 1`] = `
+Array [
+  Object {
+    "component": [Function],
+    "name": "Celebrate",
+    "navigationAction": "nav/GROUP_CELEBRATE",
+  },
+  Object {
+    "component": [Function],
+    "name": "Members",
+    "navigationAction": "nav/GROUP_MEMBERS",
+  },
+  Object {
+    "component": [Function],
+    "name": "Impact",
+    "navigationAction": "nav/GROUP_IMPACT",
+  },
+  Object {
+    "component": [Function],
+    "name": "Contacts",
+    "navigationAction": "nav/GROUP_CONTACTS",
+  },
+  Object {
+    "component": [Function],
+    "name": "Surveys",
+    "navigationAction": "nav/GROUP_SURVEYS",
+  },
+]
+`;
+
+exports[`GroupScreen should render User Created Community tabs correctly 1`] = `
+Array [
+  Object {
+    "component": [Function],
+    "name": "Celebrate",
+    "navigationAction": "nav/GROUP_CELEBRATE",
+  },
+  Object {
+    "component": [Function],
+    "name": "Challenges",
+    "navigationAction": "nav/GROUP_CHALLENGES",
+  },
+  Object {
+    "component": [Function],
+    "name": "Members",
+    "navigationAction": "nav/GROUP_MEMBERS",
+  },
+  Object {
+    "component": [Function],
+    "name": "Impact",
+    "navigationAction": "nav/GROUP_IMPACT",
+  },
+]
+`;
+
 exports[`GroupScreen should render header correctly 1`] = `
 <Connect(Header)
   left={<Connect(BackButton) />}

--- a/src/containers/Groups/GroupScreen.js
+++ b/src/containers/Groups/GroupScreen.js
@@ -148,12 +148,15 @@ const tabs = [
   },
 ];
 
+export const CRU_TABS = [tabs[0], ...tabs.slice(2, 6)];
+export const USER_CREATED_TABS = tabs.slice(0, 4);
+
 export const groupScreenTabNavigator = generateSwipeTabMenuNavigator(
-  tabs,
+  CRU_TABS,
   GroupScreen,
 );
 export const userCreatedScreenTabNavigator = generateSwipeTabMenuNavigator(
-  tabs.slice(0, 4),
+  USER_CREATED_TABS,
   GroupScreen,
 );
 


### PR DESCRIPTION
Apparently we only want the Challenges features for our user-created test groups, not for Cru communities at the moment.