### PR TITLE
Remove patch target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,10 +1,4 @@
 codecov:
   token: c4a5784a-81a2-4c65-a5ae-bef23f5ac97a
 
-coverage:
-  status:
-    patch:
-      default:
-        target: 80%
-
 comment: false


### PR DESCRIPTION
Hey guys.  How do you feel with the current code coverage requirement?  Since we have passed 80%, the patch requirement doesn't do anything because we have the project check.

Therefore, unless we want to make 80% the bar (as opposed to the current project level), we might as well remove this.