### PR TITLE
Grab the org from the selector instead of the prop.

### DIFF
--- a/src/containers/Groups/Members.js
+++ b/src/containers/Groups/Members.js
@@ -136,6 +136,7 @@ const mapStateToProps = ({ auth, organizations, swipe }, { organization }) => {
       person: auth.person,
       organization: { id: organization.id },
     }),
+    organization: selectorOrg || organization,
   };
 };
 

--- a/src/containers/Groups/__tests__/Members.js
+++ b/src/containers/Groups/__tests__/Members.js
@@ -39,11 +39,12 @@ const members = [
 const orgId = '1';
 const myId = '111';
 
+const organization = { id: orgId, name: 'Test Org' };
 const store = createMockStore({
   organizations: {
     all: [
       {
-        id: orgId,
+        ...organization,
         members,
       },
     ],
@@ -62,8 +63,6 @@ const store = createMockStore({
   },
   swipe: { groupInviteInfo: true },
 });
-
-const organization = { id: '1', name: 'Test Org' };
 
 beforeEach(() => {
   navToPersonScreen.mockClear();
@@ -168,7 +167,10 @@ describe('Members', () => {
 
     listItem.props.onSelect(member);
 
-    expect(navToPersonScreen).toHaveBeenCalledWith(member, organization);
+    expect(navToPersonScreen).toHaveBeenCalledWith(member, {
+      ...organization,
+      members,
+    });
   });
 
   it('should handleLoadMore correctly', () => {

--- a/src/containers/Groups/__tests__/__snapshots__/Members.js.snap
+++ b/src/containers/Groups/__tests__/__snapshots__/Members.js.snap
@@ -13,6 +13,23 @@ exports[`Members calls render item 1`] = `
   organization={
     Object {
       "id": "1",
+      "members": Array [
+        Object {
+          "contact_assignments": Array [],
+          "full_name": "Test User 1",
+          "id": "1",
+        },
+        Object {
+          "contact_assignments": Array [],
+          "full_name": "Test User 2",
+          "id": "2",
+        },
+        Object {
+          "contact_assignments": Array [],
+          "full_name": "Test User 3",
+          "id": "3",
+        },
+      ],
       "name": "Test Org",
     }
   }


### PR DESCRIPTION
This fixes the issue where the community url is null after it was updated from the profile and then you go right back into the members page.