### PR TITLE
Mhp 2180 -- Leave Person View after Delete Contact

### DIFF
--- a/src/components/PersonSideMenu/__tests__/PersonSideMenu.js
+++ b/src/components/PersonSideMenu/__tests__/PersonSideMenu.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Alert } from 'react-native';
-import { DrawerActions } from 'react-navigation';
 
 import PersonSideMenu from '..';
 
@@ -143,8 +142,7 @@ describe('PersonSideMenu', () => {
       //Manually call onPress
       Alert.alert.mock.calls[0][2][1].onPress();
       expect(component.instance().deleteOnUnmount).toEqual(true);
-      expect(DrawerActions.closeDrawer).toHaveBeenCalled();
-      expect(navigateBack).toHaveBeenCalledTimes(1);
+      expect(navigateBack).toHaveBeenCalledWith(2);
     });
 
     describe('componentWillUnmount', () => {

--- a/src/components/PersonSideMenu/index.js
+++ b/src/components/PersonSideMenu/index.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 import { Alert } from 'react-native';
-import { DrawerActions } from 'react-navigation';
 import PropTypes from 'prop-types';
 
 import { deleteContactAssignment } from '../../actions/person';


### PR DESCRIPTION
Bug: after selecting "Delete" button from person side menu, the drawer closes but the user is not brought back to the people list, as they should be.

Problem: there seemed to be conflicting navigation commands when calling `DrawerActions.closeDrawer()` and `NavigateActions.back()` one after another.  They both interact with the navigation stack, and there seems to be issues with calling multiple types of navigation actions at once.  Even awaiting a promise from dispatching `closDrawer()` seemed problematic. https://github.com/react-navigation/react-navigation/issues/978

Solution: It seemed simplest to call `navigateBack(2)`, because it will pop the last two items from the navgation stack, including the open drawer action.