### PR TITLE
Add transparent underline to all android text inputs.

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,6 +3,7 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
+        <item name="android:editTextBackground">@android:color/transparent</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Solution is from here: https://github.com/facebook/react-native/issues/17530#issuecomment-416367184

We're not showing an underline color for android anywhere, so this is alright.

As a side note, I think there's some cool things we can do with the android app. Header/background colors for the android app switcher, better status bar for android, better notification icons. We just haven't spent much time on those small android details.