### PR TITLE
Update community url to mhub.cc/c/

### DIFF
--- a/.env.beta
+++ b/.env.beta
@@ -7,6 +7,6 @@ CODEPUSH_IOS_KEY=4bsiFXfrq6noANyLty9mcN4UUaXsBkuyvzgjz
 CODEPUSH_ANDROID_KEY=D7J-HDM60x7vK7ZgeQPmujzIAFlar1m_vfgoG
 ROLLBAR_ACCESS_TOKEN=cc5609149689437ca513dd2b8df06c80
 SURVEY_URL=https://mhub.cc/s/
-COMMUNITY_URL=https://stage.missionhub.com/
+COMMUNITY_URL=https://mhub.cc/c/
 SNOWPLOW_URL=snowplow-stage.cru.org
 SNOWPLOW_APP_ID=missionhub-dev

--- a/.env.production
+++ b/.env.production
@@ -7,6 +7,6 @@ CODEPUSH_IOS_KEY=RMh4ltLXWiWdIuVR9OA_tDx090q1HyKyvfeiz
 CODEPUSH_ANDROID_KEY=LqJUzFeeGRfzla_Ed-GT2duno8yFHJXdwfeiG
 ROLLBAR_ACCESS_TOKEN=cc5609149689437ca513dd2b8df06c80
 SURVEY_URL=https://mhub.cc/s/
-COMMUNITY_URL=https://missionhub.com/
+COMMUNITY_URL=https://mhub.cc/c/
 SNOWPLOW_URL=s.cru.org
 SNOWPLOW_APP_ID=missionhub-app


### PR DESCRIPTION
.env.beta seems to be using the prod API so I set the mhub.cc links to also hit prod. I don't think we're really using it anywhere.