### PR TITLE
MHP-2264: Delete push token before logout action

### DIFF
--- a/src/actions/__tests__/auth.js
+++ b/src/actions/__tests__/auth.js
@@ -294,18 +294,18 @@ describe('refreshAnonymousLogin', () => {
 });
 
 describe('logout', () => {
-  it('should perform the needed actions for signing out', () => {
+  it('should perform the needed actions for signing out', async () => {
     deletePushToken.mockReturnValue({
       type: REQUESTS.DELETE_PUSH_TOKEN.SUCCESS,
     });
-    store.dispatch(logout());
+    await store.dispatch(logout());
     expect(store.getActions()).toMatchSnapshot();
   });
-  it('should perform the needed actions for forced signing out', () => {
+  it('should perform the needed actions for forced signing out', async () => {
     deletePushToken.mockReturnValue({
       type: REQUESTS.DELETE_PUSH_TOKEN.SUCCESS,
     });
-    store.dispatch(logout(true));
+    await store.dispatch(logout(true));
     expect(store.getActions()).toMatchSnapshot();
   });
 });

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -161,8 +161,8 @@ export function refreshAnonymousLogin() {
 }
 
 export function logout(forcedLogout = false) {
-  return dispatch => {
-    dispatch(deletePushToken());
+  return async dispatch => {
+    await dispatch(deletePushToken());
     dispatch({ type: LOGOUT });
     dispatch(
       forcedLogout


### PR DESCRIPTION
Since the API updates the JWT on every API request, we were firing logout and then the API request would come back and we'd store the new JWT causing there to be a token next time navigationInit was run which sent you to onboarding.