### PR TITLE
Fix person screen stage display by fixing contact assignment lookup

### DIFF
--- a/src/containers/Groups/AssignedPersonScreen/index.js
+++ b/src/containers/Groups/AssignedPersonScreen/index.js
@@ -284,7 +284,7 @@ export const mapStateToProps = (
   const person = personSelector({ people }, { personId, orgId }) || navPerson;
   const contactAssignment = contactAssignmentSelector(
     { auth },
-    { person, orgId },
+    { person, orgId: organization.id },
   );
   const authPerson = auth.person;
 


### PR DESCRIPTION
Undoes https://github.com/CruGlobal/missionhub-react-native/pull/695/files#diff-1b8599b83a46faa120ce2951410f66a9R288. The stage button was missing for at least try it now contacts not in a group. Idk if it was more widespread.

`contactAssignmentSelector` doesn't know how to handle an orgId of `personal`. Robert's addition of null checks and swapping the org variable started passing in `personal` which resulted in it not finding contact assignments when it should.