### PR TITLE
Add back person tabs for Cru orgs

### DIFF
--- a/src/containers/Groups/AssignedPersonScreen/__tests__/__snapshots__/AssignedPersonScreen.js.snap
+++ b/src/containers/Groups/AssignedPersonScreen/__tests__/__snapshots__/AssignedPersonScreen.js.snap
@@ -380,6 +380,21 @@ Array [
   },
   Object {
     "component": [Function],
+    "name": "My Steps",
+    "navigationAction": "nav/PERSON_STEPS",
+  },
+  Object {
+    "component": [Function],
+    "name": "My Notes",
+    "navigationAction": "nav/PERSON_NOTES",
+  },
+  Object {
+    "component": [Function],
+    "name": "Our Journey",
+    "navigationAction": "nav/PERSON_JOURNEY",
+  },
+  Object {
+    "component": [Function],
     "name": "Impact",
     "navigationAction": "nav/MEMBER_IMPACT",
   },

--- a/src/containers/Groups/AssignedPersonScreen/index.js
+++ b/src/containers/Groups/AssignedPersonScreen/index.js
@@ -155,7 +155,9 @@ export const IS_USER_CREATED_MEMBER_PERSON_TABS = [
   memberImpact,
 ];
 export const IS_GROUPS_MEMBER_PERSON_TABS = [
-  ...IS_USER_CREATED_MEMBER_PERSON_TABS,
+  memberCelebrate,
+  ...CONTACT_PERSON_TABS,
+  memberImpact,
   assignedContacts,
 ];
 const MEMBER_PERSON_TABS = [...CONTACT_PERSON_TABS, memberImpact];


### PR DESCRIPTION
I removed too much here https://github.com/CruGlobal/missionhub-react-native/pull/734 and didn't fully realize the tab config was shared with Cru orgs.