### PR TITLE
Open react-native-debugger on debugger launch if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "start": "REACT_DEBUGGER=\"open -g 'rndebugger://set-debugger-loc?port=8081' ||\" react-native start",
     "open": "open ios/MissionHub.xcworkspace/",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Ran across this today. We don't have to do this. Idk everyone else's development habits.

https://github.com/jhen0409/react-native-debugger/blob/master/docs/getting-started.md#the-rndebugger-uri-scheme