### PR TITLE
MHP-2542 -- Fix font style for StepDetailScreen

### DIFF
--- a/src/components/StepDetailScreen/__tests__/__snapshots__/StepDetailScreen.js.snap
+++ b/src/components/StepDetailScreen/__tests__/__snapshots__/StepDetailScreen.js.snap
@@ -42,6 +42,7 @@ exports[`markdown is not null renders correctly 1`] = `
     ellipsizeMode="tail"
     style={
       Object {
+        "fontFamily": "SourceSansPro-Light",
         "fontSize": 32,
         "fontWeight": "300",
         "lineHeight": 38,
@@ -644,6 +645,7 @@ exports[`markdown is null bottomButtonProps are not null renders correctly 1`] =
     ellipsizeMode="tail"
     style={
       Object {
+        "fontFamily": "SourceSansPro-Light",
         "fontSize": 32,
         "fontWeight": "300",
         "lineHeight": 38,
@@ -713,6 +715,7 @@ exports[`markdown is null bottomButtonProps are null renders correctly 1`] = `
     ellipsizeMode="tail"
     style={
       Object {
+        "fontFamily": "SourceSansPro-Light",
         "fontSize": 32,
         "fontWeight": "300",
         "lineHeight": 38,

--- a/src/components/StepDetailScreen/styles.js
+++ b/src/components/StepDetailScreen/styles.js
@@ -17,6 +17,7 @@ export default StyleSheet.create({
   stepTitleText: {
     fontSize: 32,
     lineHeight: 38,
+    fontFamily: 'SourceSansPro-Light',
     fontWeight: '300',
     marginVertical: 16,
     marginHorizontal: 32,


### PR DESCRIPTION
It looks like Android does not respond to `fontWeight` the same as iOS, and does not render with the skinnier font on the StepDetailScreen.  I chose to use `fontFamily` here to ensure that the right font is being used.