### PR TITLE
MHP-2546: Use API data for comment notifications

### DIFF
--- a/src/actions/unreadComments.js
+++ b/src/actions/unreadComments.js
@@ -1,14 +1,5 @@
 // import callApi, { REQUESTS } from './api';
 
-// export function getUnreadComments(orgId) {
-//   return dispatch =>
-//     dispatch(callApi(REQUESTS.GET_CELEBRATE_COMMENTS, { orgId }));
-// }
-// TODO: Implement this
-export function getUnreadComments() {
-  return { type: 'blank' };
-}
-
 // export function markCommentsRead(orgId) {
 //   return dispatch =>
 //     dispatch(callApi(REQUESTS.GET_CELEBRATE_COMMENTS, { orgId }));

--- a/src/components/GroupCardItem/__tests__/GroupCardItem.js
+++ b/src/components/GroupCardItem/__tests__/GroupCardItem.js
@@ -15,6 +15,7 @@ const group = {
   name: 'Group Name',
   contactReport: {},
   user_created: false,
+  unread_comments_count: 0,
 };
 
 let props = {
@@ -167,7 +168,7 @@ describe('GroupCardItem', () => {
       ...props,
       group: {
         ...group,
-        has_unread_comments_for_user: true,
+        unread_comments_count: 11,
       },
     };
 

--- a/src/components/GroupCardItem/index.js
+++ b/src/components/GroupCardItem/index.js
@@ -78,8 +78,7 @@ export default class GroupCardItem extends Component {
     const { t, group, onPress, onJoin } = this.props;
     const source = this.getSource();
 
-    // TODO: Figure this out from the API
-    const hasNotification = group.has_unread_comments_for_user;
+    const hasNotification = group.unread_comments_count !== 0;
 
     //not passing a value for onPress to Card makes the card unclickable.
     //In some cases we want to prevent clicking on GroupCardItem.

--- a/src/containers/CelebrateFeedHeader/__tests__/CelebrateFeedHeader.js
+++ b/src/containers/CelebrateFeedHeader/__tests__/CelebrateFeedHeader.js
@@ -9,10 +9,7 @@ import { organizationSelector } from '../../../selectors/organizations';
 import { ORG_PERMISSIONS, GLOBAL_COMMUNITY_ID } from '../../../constants';
 import { navigatePush } from '../../../actions/navigation';
 import { GROUPS_REPORT_SCREEN } from '../../Groups/GroupReport';
-import {
-  markCommentsRead,
-  getUnreadComments,
-} from '../../../actions/unreadComments';
+import { markCommentsRead } from '../../../actions/unreadComments';
 
 import CelebrateFeedHeader from '..';
 
@@ -23,7 +20,6 @@ jest.mock('../../../actions/navigation');
 jest.mock('../../../actions/unreadComments');
 
 getReportedComments.mockReturnValue(() => ({ type: 'getReportedComments' }));
-getUnreadComments.mockReturnValue(() => ({ type: 'getUnreadComments' }));
 markCommentsRead.mockReturnValue(() => ({ type: 'markCommentsRead' }));
 navigatePush.mockReturnValue(() => ({ type: 'navigatePush' }));
 
@@ -33,6 +29,7 @@ const organization = {
   id: '1',
   user_created: true,
   reportedComments: [comment1],
+  unread_comments_count: 12,
 };
 const me = { id: 'myId' };
 
@@ -82,16 +79,22 @@ describe('unread comments card', () => {
   it('renders comment card', () => {
     const screen = buildScreen();
     expect(screen).toMatchSnapshot();
-    expect(getUnreadComments).toHaveBeenCalledWith(organization.id);
   });
-  it('renders no comment card', () => {
+  it('renders no comment card when global org', () => {
     organizationSelector.mockReturnValue({
       ...organization,
       id: GLOBAL_COMMUNITY_ID,
     });
     const screen = buildScreen();
     expect(screen).toMatchSnapshot();
-    expect(getUnreadComments).not.toHaveBeenCalled();
+  });
+  it('renders no comment card when no new comments', () => {
+    organizationSelector.mockReturnValue({
+      ...organization,
+      unread_comments_count: 0,
+    });
+    const screen = buildScreen();
+    expect(screen).toMatchSnapshot();
   });
 });
 
@@ -124,7 +127,6 @@ describe('admin', () => {
     const screen = buildScreen();
     expect(screen).toMatchSnapshot();
     expect(getReportedComments).not.toHaveBeenCalled();
-    expect(getUnreadComments).not.toHaveBeenCalled();
   });
 });
 
@@ -167,7 +169,6 @@ describe('global community org', () => {
     const screen = buildScreen();
     expect(screen).toMatchSnapshot();
     expect(getReportedComments).not.toHaveBeenCalled();
-    expect(getUnreadComments).not.toHaveBeenCalled();
   });
 });
 

--- a/src/containers/CelebrateFeedHeader/__tests__/__snapshots__/CelebrateFeedHeader.js.snap
+++ b/src/containers/CelebrateFeedHeader/__tests__/__snapshots__/CelebrateFeedHeader.js.snap
@@ -229,10 +229,32 @@ exports[`unread comments card renders comment card 1`] = `
 </React.Fragment>
 `;
 
-exports[`unread comments card renders no comment card 1`] = `
+exports[`unread comments card renders no comment card when global org 1`] = `
 <React.Fragment>
   <Connect(Translate(OnboardingCard))
     type="celebrate"
   />
+</React.Fragment>
+`;
+
+exports[`unread comments card renders no comment card when no new comments 1`] = `
+<React.Fragment>
+  <Connect(Translate(OnboardingCard))
+    type="celebrate"
+  />
+  <Flex
+    style={
+      Object {
+        "borderBottomColor": "#505256",
+        "borderBottomWidth": 1,
+        "padding": 20,
+      }
+    }
+  >
+    <ReportCommentHeaderCard
+      count={1}
+      onPress={[Function]}
+    />
+  </Flex>
 </React.Fragment>
 `;

--- a/src/containers/CelebrateFeedHeader/index.js
+++ b/src/containers/CelebrateFeedHeader/index.js
@@ -12,10 +12,7 @@ import { GROUPS_REPORT_SCREEN } from '../Groups/GroupReport';
 import OnboardingCard, {
   GROUP_ONBOARDING_TYPES,
 } from '../../containers/Groups/OnboardingCard';
-import {
-  getUnreadComments,
-  markCommentsRead,
-} from '../../actions/unreadComments';
+import { markCommentsRead } from '../../actions/unreadComments';
 import UnreadCommentsCard from '../../components/UnreadCommentsCard';
 import ReportCommentHeaderCard from '../../components/ReportCommentHeaderCard';
 
@@ -27,13 +24,9 @@ class CelebrateFeedHeader extends Component {
       dispatch,
       organization: { id: orgId },
       shouldQueryReport,
-      shouldQueryNewComments,
     } = this.props;
     if (shouldQueryReport) {
       dispatch(getReportedComments(orgId));
-    }
-    if (shouldQueryNewComments) {
-      dispatch(getUnreadComments(orgId));
     }
   }
 
@@ -122,16 +115,14 @@ export const mapStateToProps = (
   const isCruOrg = orgIsCru(selectorOrg);
 
   const shouldQueryReport = isCruOrg ? isUserAdmin : isUserOwner;
-  const shouldQueryNewComments = !orgIsGlobal(selectorOrg);
-  const newCommentsCount = 12; // TODO: Connect this to the right data
+  const newCommentsCount = selectorOrg.unread_comments_count;
 
   return {
     organization: selectorOrg,
     shouldQueryReport,
     isReportVisible: shouldQueryReport && reportedCount !== 0,
     reportedCount,
-    isCommentCardVisible: shouldQueryNewComments && newCommentsCount !== 0,
-    shouldQueryNewComments,
+    isCommentCardVisible: !orgIsGlobal(selectorOrg) && newCommentsCount !== 0,
     newCommentsCount,
   };
 };

--- a/src/containers/TabIcon/__tests__/TabIcon.js
+++ b/src/containers/TabIcon/__tests__/TabIcon.js
@@ -15,10 +15,10 @@ const buildScreen = (props = {}) => {
 };
 
 const storeActive = {
-  auth: { person: { hasActiveNotification: true } },
+  auth: { person: { unread_comments_count: 10 } },
 };
 const storeInactive = {
-  auth: { person: { hasActiveNotification: false } },
+  auth: { person: { unread_comments_count: 0 } },
 };
 
 beforeEach(() => {

--- a/src/containers/TabIcon/index.js
+++ b/src/containers/TabIcon/index.js
@@ -37,7 +37,6 @@ function TabIcon({ name, tintColor, showNotification }) {
 }
 
 const mapStateToProps = ({ auth }, { name }) => ({
-  // TODO: Get the right variable here to show the notification dot
-  showNotification: name === 'group' && auth.person.hasActiveNotification,
+  showNotification: name === 'group' && auth.person.unread_comments_count,
 });
 export default connect(mapStateToProps)(TabIcon);


### PR DESCRIPTION
@bryaneaton13 Not sure if you are working currently but wanted to check and make sure I got everything you had a TODO for. https://jira.cru.org/browse/MHP-2523 will take care of the filtered feed, navigating there, and filtering items so that data isn't loaded by this PR.

I may still need to do some refreshing and/or client-side resetting of these counts either in this PR or a follow up one. Not sure how that worksI started a conversation here https://jira.cru.org/browse/MHP-2546?focusedCommentId=79220&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-79220.