### PR TITLE
MHP-2550: Mark comments as read

### DIFF
--- a/src/actions/__tests__/unreadComments.js
+++ b/src/actions/__tests__/unreadComments.js
@@ -1,0 +1,23 @@
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import callApi, { REQUESTS } from '../api';
+import { markCommentsRead } from '../unreadComments';
+
+jest.mock('../api');
+callApi.mockReturnValue(() => {
+  result: 'marked as unread';
+});
+
+describe('markCommentsRead', () => {
+  it("should send a request to mark an org's comments as read", () => {
+    const orgId = 4;
+    const { dispatch } = configureStore([thunk])();
+
+    dispatch(markCommentsRead(orgId));
+
+    expect(callApi).toHaveBeenCalledWith(REQUESTS.MARK_ORG_COMMENTS_AS_READ, {
+      organization_id: orgId,
+    });
+  });
+});

--- a/src/actions/unreadComments.js
+++ b/src/actions/unreadComments.js
@@ -1,10 +1,10 @@
-// import callApi, { REQUESTS } from './api';
+import callApi, { REQUESTS } from './api';
 
-// export function markCommentsRead(orgId) {
-//   return dispatch =>
-//     dispatch(callApi(REQUESTS.GET_CELEBRATE_COMMENTS, { orgId }));
-// }
-// TODO: Implement this
-export function markCommentsRead() {
-  return { type: 'blank' };
+export function markCommentsRead(orgId) {
+  return dispatch =>
+    dispatch(
+      callApi(REQUESTS.MARK_ORG_COMMENTS_AS_READ, {
+        organization_id: orgId,
+      }),
+    );
 }

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -227,6 +227,10 @@ export default {
     endpoint: `${ORG_URL}/:orgId/celebration_items/:eventId/comments/:commentId`,
     method: 'delete',
   },
+  MARK_ORG_COMMENTS_AS_READ: {
+    endpoint: `${API_URL}/unread_items`,
+    method: 'delete',
+  },
   GET_REPORTED_COMMENTS: {
     endpoint: `${ORG_URL}/:orgId/comment_reports`,
   },

--- a/src/containers/CelebrateFeedHeader/index.js
+++ b/src/containers/CelebrateFeedHeader/index.js
@@ -31,8 +31,11 @@ class CelebrateFeedHeader extends Component {
   }
 
   closeCommentCard = () => {
-    const { dispatch } = this.props;
-    dispatch(markCommentsRead());
+    const {
+      dispatch,
+      organization: { id: orgId },
+    } = this.props;
+    dispatch(markCommentsRead(orgId));
   };
 
   report = () => {


### PR DESCRIPTION
This doesn't implement marking comments as read when loading the feed. I figured there would be a race condition between marking as read and trying to load items by unread. One of us can do that in the filtered feed component once both this and #897 are merged.