### PR TITLE
MHP-2588 fix -- use showNotificationPrompt after join community

### DIFF
--- a/src/routes/groups/__tests__/joinByCodeFlow.js
+++ b/src/routes/groups/__tests__/joinByCodeFlow.js
@@ -5,7 +5,7 @@ import thunk from 'redux-thunk';
 import { JOIN_GROUP_SCREEN } from '../../../containers/Groups/JoinGroupScreen';
 import { JoinByCodeFlowScreens } from '../joinByCodeFlow';
 import { renderShallow } from '../../../../testUtils';
-import { showReminderOnLoad } from '../../../actions/notifications';
+import { showNotificationPrompt } from '../../../actions/notifications';
 import { joinCommunity } from '../../../actions/organizations';
 import {
   GROUP_TAB_SCROLL_ON_MOUNT,
@@ -27,7 +27,7 @@ beforeEach(() => {
 describe('JoinGroupScreen next', () => {
   it('should fire required next actions', async () => {
     joinCommunity.mockReturnValue(() => Promise.resolve());
-    showReminderOnLoad.mockReturnValue(() => Promise.resolve());
+    showNotificationPrompt.mockReturnValue(() => Promise.resolve());
 
     const WrappedJoinGroupScreen =
       JoinByCodeFlowScreens[JOIN_GROUP_SCREEN].screen;
@@ -42,7 +42,7 @@ describe('JoinGroupScreen next', () => {
       community.id,
       community.community_code,
     );
-    expect(showReminderOnLoad).toHaveBeenCalledWith(
+    expect(showNotificationPrompt).toHaveBeenCalledWith(
       NOTIFICATION_PROMPT_TYPES.JOIN_COMMUNITY,
       true,
     );

--- a/src/routes/groups/joinByCodeFlow.js
+++ b/src/routes/groups/joinByCodeFlow.js
@@ -7,7 +7,7 @@ import JoinGroupScreen, {
 import { buildTrackedScreen, wrapNextAction } from '../helpers';
 import { buildTrackingObj } from '../../utils/common';
 import { MAIN_TABS, NOTIFICATION_PROMPT_TYPES } from '../../constants';
-import { showReminderOnLoad } from '../../actions/notifications';
+import { showNotificationPrompt } from '../../actions/notifications';
 import { joinCommunity } from '../../actions/organizations';
 import { setScrollGroups } from '../../actions/swipe';
 
@@ -16,7 +16,7 @@ export const JoinByCodeFlowScreens = {
     wrapNextAction(JoinGroupScreen, ({ community }) => async dispatch => {
       await dispatch(joinCommunity(community.id, community.community_code));
       await dispatch(
-        showReminderOnLoad(NOTIFICATION_PROMPT_TYPES.JOIN_COMMUNITY, true),
+        showNotificationPrompt(NOTIFICATION_PROMPT_TYPES.JOIN_COMMUNITY, true),
       );
       dispatch(setScrollGroups(community.id));
       dispatch(navigateReset(MAIN_TABS, { startTab: 'groups' }));


### PR DESCRIPTION
I referenced the wrong method in this spot.  `showReminderOnLoad` will only check for notification permissons in certain conditions.  `showNotificationPrompt` will always check for permissions.  The latter is what we need in this case.