### PR TITLE
Avoid running oneskyDownload script during tests

### DIFF
--- a/bin/__tests__/translationHelpers.js
+++ b/bin/__tests__/translationHelpers.js
@@ -1,4 +1,4 @@
-import { filterReadyTranslations } from '../oneskyDownload';
+import { filterReadyTranslations } from '../translationHelpers';
 
 const inputTranslations =
   '{"en":{"phrase1":"1"},"es":{"phrase1":"1"},"no":{"phrase1":"1"}}';

--- a/bin/oneskyDownload.js
+++ b/bin/oneskyDownload.js
@@ -3,26 +3,9 @@ import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
 import oneSky from '@brainly/onesky-utils';
+import { filterReadyTranslations } from './translationHelpers';
 
 dotenv.config({ path: '.env.local' });
-
-export function filterReadyTranslations(translationsRaw, languagesRaw) {
-  const readyLanguages = JSON.parse(languagesRaw)
-    .data.filter(language => language.is_ready_to_publish)
-    .map(language => language.code);
-
-  const translations = JSON.parse(translationsRaw);
-
-  const content = readyLanguages.reduce(
-    (acc, language) => ({
-      ...acc,
-      [language]: translations[language],
-    }),
-    {},
-  );
-
-  return JSON.stringify(content);
-}
 
 async function downloadTranslations() {
   const options = {

--- a/bin/translationHelpers.js
+++ b/bin/translationHelpers.js
@@ -1,0 +1,17 @@
+export function filterReadyTranslations(translationsRaw, languagesRaw) {
+  const readyLanguages = JSON.parse(languagesRaw)
+    .data.filter(language => language.is_ready_to_publish)
+    .map(language => language.code);
+
+  const translations = JSON.parse(translationsRaw);
+
+  const content = readyLanguages.reduce(
+    (acc, language) => ({
+      ...acc,
+      [language]: translations[language],
+    }),
+    {},
+  );
+
+  return JSON.stringify(content);
+}


### PR DESCRIPTION
- Move filterReadyTranslations to a new file

I noticed `Downloading from OneSky...` in the travis jest logs. Idk if it was just the console log or if it was actually attempting a download. Either way we don't need to run it there. Figured I'd just fix it...