### PR TITLE
Prepare for API id number to string conversion

### DIFF
--- a/src/components/GroupMemberItem/__tests__/__snapshots__/GroupMemberItem.js.snap
+++ b/src/components/GroupMemberItem/__tests__/__snapshots__/GroupMemberItem.js.snap
@@ -207,7 +207,7 @@ exports[`render MemberOptionsMenu should render menu if I am admin and person is
       personOrgPermission={
         Object {
           "id": "111",
-          "permission_id": 4,
+          "permission_id": "4",
         }
       }
     />
@@ -296,7 +296,7 @@ exports[`render MemberOptionsMenu should render menu if person is me 1`] = `
       personOrgPermission={
         Object {
           "id": "111",
-          "permission_id": 4,
+          "permission_id": "4",
         }
       }
     />

--- a/src/components/GroupMemberItem/index.js
+++ b/src/components/GroupMemberItem/index.js
@@ -28,7 +28,7 @@ class GroupMemberItem extends Component {
       return '';
     }
 
-    switch (personOrgPermission.permission_id) {
+    switch (`${personOrgPermission.permission_id}`) {
       case ORG_PERMISSIONS.ADMIN:
         return t('profileLabels.admin');
       case ORG_PERMISSIONS.OWNER:

--- a/src/constants.js
+++ b/src/constants.js
@@ -102,10 +102,10 @@ export const LINKS = {
 export const ANALYTICS_CONTEXT_CHANGED = 'app/ANALYTICS_CONTEXT_CHANGED';
 
 export const ORG_PERMISSIONS = {
-  ADMIN: 1,
-  USER: 4,
-  CONTACT: 2,
-  OWNER: 3,
+  ADMIN: '1',
+  USER: '4',
+  CONTACT: '2',
+  OWNER: '3',
 };
 export const GCM_SENDER_ID = Config.GCM_SENDER_ID;
 

--- a/src/containers/AddContactFields/__tests__/__snapshots__/AddContactFields.js.snap
+++ b/src/containers/AddContactFields/__tests__/__snapshots__/AddContactFields.js.snap
@@ -356,7 +356,7 @@ exports[`renders jean with organization and user and admin radio buttons 1`] = `
       onSelect={[Function]}
       pressProps={
         Array [
-          2,
+          "2",
         ]
       }
       size={25}
@@ -553,7 +553,7 @@ exports[`renders jean with organization and user radio buttons 1`] = `
       onSelect={[Function]}
       pressProps={
         Array [
-          2,
+          "2",
         ]
       }
       size={25}
@@ -750,7 +750,7 @@ exports[`renders jean with organization view correctly 1`] = `
       onSelect={[Function]}
       pressProps={
         Array [
-          2,
+          "2",
         ]
       }
       size={25}

--- a/src/containers/AddContactFields/index.js
+++ b/src/containers/AddContactFields/index.js
@@ -132,7 +132,7 @@ class AddContactFields extends Component {
       orgPermission,
     } = this.state;
 
-    const selectedOrgPermId = orgPermission.permission_id;
+    const selectedOrgPermId = `${orgPermission.permission_id}`;
     // Email is required if the new person is going to be a user or admin for an organization
     const isEmailRequired = hasOrgPermissions(orgPermission);
 

--- a/src/containers/CommentsList/index.js
+++ b/src/containers/CommentsList/index.js
@@ -14,10 +14,9 @@ import {
 } from '../../actions/celebrateComments';
 import { reportComment } from '../../actions/reportComments';
 import LoadMore from '../../components/LoadMore';
-import { showMenu, keyExtractorId } from '../../utils/common';
+import { showMenu, keyExtractorId, isOwner } from '../../utils/common';
 import CommentItem from '../CommentItem';
 import { orgPermissionSelector } from '../../selectors/people';
-import { ORG_PERMISSIONS } from '../../constants';
 
 import styles from './styles';
 
@@ -109,7 +108,7 @@ class CommentsList extends Component {
           person: me,
           organization,
         }) || {};
-      if (orgPermission.permission_id === ORG_PERMISSIONS.OWNER) {
+      if (isOwner(orgPermission)) {
         actions.push(deleteAction);
       } else {
         actions.push({

--- a/src/containers/Groups/GroupProfile/index.js
+++ b/src/containers/Groups/GroupProfile/index.js
@@ -35,7 +35,7 @@ import {
 } from '../../../actions/organizations';
 import { trackActionWithoutData } from '../../../actions/analytics';
 import { organizationSelector } from '../../../selectors/organizations';
-import { ORG_PERMISSIONS, ACTIONS, GROUPS_TAB } from '../../../constants';
+import { ACTIONS, GROUPS_TAB } from '../../../constants';
 import { orgPermissionSelector } from '../../../selectors/people';
 import PopupMenu from '../../../components/PopupMenu';
 import Header from '../../../components/Header';
@@ -326,8 +326,7 @@ const mapStateToProps = ({ auth, organizations }, { navigation }) => {
   const owner = members.find(({ organizational_permissions = [] }) =>
     organizational_permissions.find(
       orgPermission =>
-        orgPermission.organization_id === orgId &&
-        orgPermission.permission_id === ORG_PERMISSIONS.OWNER,
+        orgPermission.organization_id === orgId && isOwner(orgPermission),
     ),
   );
   const myOrgPerm = orgPermissionSelector(null, {

--- a/src/containers/Groups/__tests__/GroupChallenges.js
+++ b/src/containers/Groups/__tests__/GroupChallenges.js
@@ -108,7 +108,7 @@ describe('mapStateToProps', () => {
     expect(mapStateToProps(store, { organization: org })).toEqual({
       challengeItems: challengeSelectorReturnValue,
       myOrgPermissions: {
-        permission_id: 1,
+        permission_id: '1',
       },
       pagination: challengePagination,
     });

--- a/src/containers/Groups/__tests__/__snapshots__/Members.js.snap
+++ b/src/containers/Groups/__tests__/__snapshots__/Members.js.snap
@@ -5,7 +5,7 @@ exports[`Members calls render item 1`] = `
   myOrgPermission={
     Object {
       "organization_id": "1",
-      "permission_id": 4,
+      "permission_id": "4",
     }
   }
   onSelect={[Function]}

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -105,16 +105,17 @@ const MHUB_PERMISSIONS = [
   ORG_PERMISSIONS.USER,
 ];
 export const hasOrgPermissions = orgPermission =>
-  !!orgPermission && MHUB_PERMISSIONS.includes(orgPermission.permission_id);
+  !!orgPermission &&
+  MHUB_PERMISSIONS.includes(`${orgPermission.permission_id}`);
 export const isAdminOrOwner = orgPermission =>
   !!orgPermission &&
   [ORG_PERMISSIONS.ADMIN, ORG_PERMISSIONS.OWNER].includes(
-    orgPermission.permission_id,
+    `${orgPermission.permission_id}`,
   );
 export const isOwner = orgPermission =>
-  !!orgPermission && orgPermission.permission_id === ORG_PERMISSIONS.OWNER;
+  !!orgPermission && `${orgPermission.permission_id}` === ORG_PERMISSIONS.OWNER;
 export const isAdmin = orgPermission =>
-  !!orgPermission && orgPermission.permission_id === ORG_PERMISSIONS.ADMIN;
+  !!orgPermission && `${orgPermission.permission_id}` === ORG_PERMISSIONS.ADMIN;
 
 export const isCustomStep = step => step.challenge_type === CUSTOM_STEP_TYPE;
 


### PR DESCRIPTION
Sheldon is working on converting the few remaining ids returned by the API to strings.
https://jira.cru.org/browse/MHP-2090
https://jira.cru.org/browse/MHP-2680
This is the only thing I've found where we're doing comparisons with numbers. This needs to go to production beforehand. But since we can't update all the old apps immediately, I'm going to have Sheldon not convert this one field until later.