### PR TITLE
Downgrade fresco to fix build error

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -163,7 +163,7 @@ dependencies {
     implementation project(':react-native-omniture')
     implementation project(':react-native-push-notification')
     implementation project(':react-native-vector-icons')
-    implementation 'com.facebook.fresco:fresco:1.+'
+    implementation 'com.facebook.fresco:fresco:1.13.0' // v1.14.0 and v1.14.1 crash on app launch with androidx error. I couldn't get a support library working. https://github.com/facebook/fresco/issues/2226
     implementation 'com.facebook.fresco:animated-base-support:1.3.0'
     implementation 'com.facebook.fresco:animated-gif:1.13.0'
 


### PR DESCRIPTION
Looks like 1.14.0 was released on May 30, 2019 https://mvnrepository.com/artifact/com.facebook.fresco/fresco. The 1.14.x releases aren't listed on Github https://github.com/facebook/fresco/releases so idk what the changelog is. But that was the date it stopped working since the `+` started picking up that version.

I added this during the RN upgrade because images stopped showing up on Android... It was working until 1.14.0 was released...

Looks like they migrated to androidx (the new Android support libraries) which we'll probably have to do once RN 0.60.0 lands. https://github.com/facebook/fresco/compare/b59414a97b6fc37269985f6d8b111b756fc42464...v1.14.0