### PR TITLE
in testUtils, remove custom rerender

### DIFF
--- a/testUtils/index.tsx
+++ b/testUtils/index.tsx
@@ -43,7 +43,6 @@ export function renderWithContext(
   return {
     ...renderResult,
     store,
-    rerender: (component: ReactElement) => renderResult.update(component),
     snapshot: () => {
       expect(renderResult.toJSON()).toMatchSnapshot();
     },


### PR DESCRIPTION
I had added this before the `render` function supported the `wrapper` option. `renderResult` contains both `rerender` and `update` which are aliases of each other. I was trying to use `rerender` in our code since that's what we will be using on web with `react-testing-library`.