### PR TITLE
MHP-2661: Force newer core-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "base64-url": "^2.2.1",
     "buffer": "^5.2.1",
     "color": "^3.1.1",
-    "core-js": "^3.1.2",
+    "core-js": "^3.1.3",
     "i18next": "^15.1.3",
     "js-sha256": "^0.9.0",
     "jsan": "^3.1.13",
@@ -123,6 +123,9 @@
     "redux-mock-store": "^1.5.3",
     "snapshot-diff": "^0.5.1",
     "typescript": "^3.4.5"
+  },
+  "resolutions": {
+    "core-js": "3.1.3"
   },
   "jest": {
     "preset": "react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2501,32 +2501,10 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-
-core-js@^2.2.2, core-js@^2.4.1:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
-
-core-js@^2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
-  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
-
-core-js@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.0.tgz#a8dbfa978d29bfc263bfb66c556d0ca924c28957"
-  integrity sha512-WBmxlgH2122EzEJ6GH8o9L/FeoUKxxxZ6q6VUxoTlsE4EvbTWKJb447eyVxTEuq0LpXjlq/kCB2qgBvsYRkLvQ==
-
-core-js@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.2.tgz#2549a2cfb3ca1a5d851c9f7838e8b282cef2f3ba"
-  integrity sha512-3poRGjbu56leCtZCZCzCgQ7GcKOflDFnjWIepaPFUsM0IXUBrne10sl3aa2Bkcz3+FjRdIxBe9dAMhIJmEnQNA==
-
-core-js@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.3.0.tgz#fab83fbb0b2d8dc85fa636c4b9d34c75420c6d65"
+core-js@3.1.3, core-js@^1.0.0, core-js@^2.2.2, core-js@^2.4.1, core-js@^2.6.5, core-js@^3.0.0, core-js@^3.1.3, core-js@~2.3.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.3.tgz#95700bca5f248f5f78c0ec63e784eca663ec4138"
+  integrity sha512-PWZ+ZfuaKf178BIAg+CRsljwjIMRV8MY00CbZczkR6Zk5LfkSkjGoaab3+bqRQWVITNZxQB7TFYz+CFcyuamvA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
According to https://github.com/zloirock/core-js/issues/368#issuecomment-376586585, this was fixed a year ago and the bad version was `2.5.3`. I don't see `2.5.3` in `yarn.lock` of our v5.1.0 release though.

If this doesn't do anything, I suppose we could try downgrading to `2.5.2` but that version is 1.5 years old at this point...

`fbjs` is requesting `core-js@1.0.0`which is from 2015... This forces that and others to `3.1.3`. Android seems to run fine.