### PR TITLE
Update iOS Fastlane Metadata

### DIFF
--- a/ios/fastlane/metadata/en-CA/marketing_url.txt
+++ b/ios/fastlane/metadata/en-CA/marketing_url.txt
@@ -1,1 +1,1 @@
-http://get.missionhub.com/
+https://get.missionhub.com/

--- a/ios/fastlane/metadata/en-CA/privacy_url.txt
+++ b/ios/fastlane/metadata/en-CA/privacy_url.txt
@@ -1,1 +1,1 @@
-
+https://get.missionhub.com/privacy/

--- a/ios/fastlane/metadata/en-CA/support_url.txt
+++ b/ios/fastlane/metadata/en-CA/support_url.txt
@@ -1,1 +1,1 @@
-http://help.missionhub.com
+https://help.missionhub.com

--- a/ios/fastlane/metadata/en-US/privacy_url.txt
+++ b/ios/fastlane/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-http://missionhub.com/privacy
+https://get.missionhub.com/privacy/

--- a/ios/fastlane/metadata/en-US/support_url.txt
+++ b/ios/fastlane/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-http://help.missionhub.com
+https://help.missionhub.com

--- a/ios/fastlane/metadata/fr-CA/marketing_url.txt
+++ b/ios/fastlane/metadata/fr-CA/marketing_url.txt
@@ -1,1 +1,1 @@
-http://qb.missionhub.com
+https://get.missionhub.com

--- a/ios/fastlane/metadata/fr-CA/privacy_url.txt
+++ b/ios/fastlane/metadata/fr-CA/privacy_url.txt
@@ -1,1 +1,1 @@
-
+https://get.missionhub.com/privacy/

--- a/ios/fastlane/metadata/fr-CA/support_url.txt
+++ b/ios/fastlane/metadata/fr-CA/support_url.txt
@@ -1,1 +1,1 @@
-http://help.missionhub.com
+https://help.missionhub.com


### PR DESCRIPTION
https://cru-main.slack.com/archives/GG22P8Y2C/p1563296233201300

Current version of metadata if you want to explore https://github.com/CruGlobal/missionhub-react-native/tree/064abdc42c9e9714684a884d1d0d6e2d1bde26dd/ios/fastlane/metadata

I assume this is how some fields in App Store Connect are set but I'm not sure. Please enlighten me if this is the wrong way to configure things :)