### PR TITLE
Fix SideMenu close icon on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -222,3 +222,9 @@ apply plugin: 'com.google.gms.google-services' // For Firebase
 com.google.gms.googleservices.GoogleServicesPlugin.config.disableVersionCheck = true // Waiting on a fix here: https://github.com/google/play-services-plugins/issues/30. Workaround from here: https://github.com/invertase/react-native-firebase/issues/1676#issuecomment-441243419.
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+
+project.ext.vectoricons = [
+    iconFontNames: [ 'MaterialIcons.ttf' ] // Name of the font files you want to copy
+]
+
+apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"


### PR DESCRIPTION
I guess this is the only place we're using Material icons... We could move this to the MissionHub fonts and then bundle one less font file...