### PR TITLE
Fix android bundle loading with codepush

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,8 +80,6 @@ import com.android.build.OutputFile
 project.ext.react = [
     entryFile: "index.js",
     enableHermes: false,  // clean and rebuild if changing
-    jsBundleDirDebug: "$buildDir/intermediates/merged_assets/debug/mergeDebugAssets/out",
-    jsBundleDirRelease: "$buildDir/intermediates/merged_assets/release/mergeReleaseAssets/out"
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
~These lines were in https://react-native-community.github.io/upgrade-helper somewhere. I'm not seeing them now.~ These were added to fix something with react-native-fabric which has since been removed https://github.com/CruGlobal/missionhub-react-native/commit/ca4010d741a241dac9c036fa97f168872df3a8a1. Codepush doesn't seem to like them.

I'm just going to move this through to master to get a working build.