### PR TITLE
MHP-2928-Fix-Back-Skip-Button-Placement

### DIFF
--- a/src/containers/BackButton/styles.js
+++ b/src/containers/BackButton/styles.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { isAndroid, hasNotch } from '../../utils/common';
+import { isAndroid } from '../../utils/common';
 
 export default StyleSheet.create({
   container: {
@@ -10,7 +10,7 @@ export default StyleSheet.create({
   },
   absoluteTopLeft: {
     position: 'absolute',
-    top: isAndroid ? 7 : hasNotch() ? 0 : 25,
+    top: isAndroid ? 7 : 25,
     left: 5,
   },
 });


### PR DESCRIPTION
Removing this check for the notch fixed the positioning of the backButton on IPhoneX. I'm not sure, was it backwards maybe? (Ex. Should it have been: `isAndroid ? 7 : hasNotch() ? 25 : 0`)