### PR TITLE
MHP-2935: Fix android shadows

### DIFF
--- a/src/components/Touchable/index.android.tsx
+++ b/src/components/Touchable/index.android.tsx
@@ -25,7 +25,7 @@ interface TouchableAndroidProps extends TouchableHighlightProps {
 const TouchableAndroid = ({
   pressProps = [],
   onPress,
-  borderless = true,
+  borderless = false,
   isAndroidOpacity,
   children,
   style,


### PR DESCRIPTION
Found this with a git bisect and deleting changes in the bad commit. Not really sure why borderless affects shadows on Android.