### PR TITLE
MHP-2922-Impact-Tab-Not-Translating

### DIFF
--- a/src/containers/Groups/AssignedPersonScreen/index.js
+++ b/src/containers/Groups/AssignedPersonScreen/index.js
@@ -97,7 +97,7 @@ const personJourney = {
   }) => <ContactJourney organization={organization} person={person} />,
 };
 const memberImpact = {
-  name: i18next.t('personTabs:Impact'),
+  name: i18next.t('personTabs:impact'),
   navigationAction: MEMBER_IMPACT,
   component: ({
     navigation: {


### PR DESCRIPTION
Changed translation key to be impact instead of Impact, which correlates to the correct translation key.