### PR TITLE
Updated-XCode-to-newer-version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
       if: branch = master and type = push
       xcode_workspace: ios/MissionHub.xcworkspace
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.2.1
       env:
         - ENVFILE=.env.production
       before_install:


### PR DESCRIPTION
Based this off of https://stackoverflow.com/questions/58743828/app-archived-with-xcode-11-2-11b52-rejected-itms-90534-invalid-toolchain since our ios build on master is failing with a similar message.