### PR TITLE
Update apollo.config.js to use env file

### DIFF
--- a/apollo.config.js
+++ b/apollo.config.js
@@ -1,16 +1,12 @@
-const prod = process.env.TRAVIS_BRANCH === 'master';
+const dotenv = require('dotenv');
+
+dotenv.config({ path: process.env.ENVFILE || '.env' });
 
 module.exports = {
   client: {
-    service:
-      false && prod // TODO: remove when prod GraphQL API is live. Helps tests pass for now
-        ? {
-            name: 'production',
-            url: 'https://api.missionhub.com/apis/graphql',
-          }
-        : {
-            name: 'staging',
-            url: 'https://api-stage.missionhub.com/apis/graphql',
-          },
+    service: {
+      name: 'missionhub-api',
+      url: `${process.env.API_BASE_URL}/apis/graphql`,
+    },
   },
 };


### PR DESCRIPTION
I was wanting to upgrade Apollo to 3.0 but it was harder than I thought and it's still a beta. I guess we'll try that later.