### PR TITLE
MHP-3055 -- change steps badge color to blue

### DIFF
--- a/src/containers/PersonItem/__tests__/__snapshots__/PersonItem.tsx.snap
+++ b/src/containers/PersonItem/__tests__/__snapshots__/PersonItem.tsx.snap
@@ -224,7 +224,7 @@ exports[`renders cru org contact correctly 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "#FF5532",
+          "backgroundColor": "#007398",
           "borderRadius": 10,
           "bottom": 16,
           "height": 20,
@@ -493,7 +493,7 @@ exports[`renders cru org contact without stage correctly 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "#FF5532",
+          "backgroundColor": "#007398",
           "borderRadius": 10,
           "bottom": 16,
           "height": 20,
@@ -698,7 +698,7 @@ exports[`renders cru org member correctly 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "#FF5532",
+          "backgroundColor": "#007398",
           "borderRadius": 10,
           "bottom": 16,
           "height": 20,
@@ -903,7 +903,7 @@ exports[`renders me correctly 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "#FF5532",
+          "backgroundColor": "#007398",
           "borderRadius": 10,
           "bottom": 16,
           "height": 20,
@@ -1108,7 +1108,7 @@ exports[`renders personal ministry contact correctly 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "#FF5532",
+          "backgroundColor": "#007398",
           "borderRadius": 10,
           "bottom": 16,
           "height": 20,
@@ -1582,7 +1582,7 @@ exports[`renders uncontacted cru org contact correctly 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "#FF5532",
+          "backgroundColor": "#007398",
           "borderRadius": 10,
           "bottom": 16,
           "height": 20,

--- a/src/containers/PersonItem/styles.ts
+++ b/src/containers/PersonItem/styles.ts
@@ -56,7 +56,7 @@ export default StyleSheet.create({
     position: 'absolute',
     bottom: 16,
     left: 20,
-    backgroundColor: theme.red,
+    backgroundColor: theme.primaryColor,
     width: 20,
     height: 20,
     borderRadius: 10,


### PR DESCRIPTION
Steve and Ivan had one quick change that they wanted me to make.  It was simple enough so I thought I would go ahead and do it.  Basically just turning the color of the accepted steps indicators on the People Screen from orange to blue.