### PR TITLE
MHP-3086: Create tooling for Apollo Hook expectations

### DIFF
--- a/__mock__/apolloHooks.ts
+++ b/__mock__/apolloHooks.ts
@@ -1,0 +1,72 @@
+import { DocumentNode } from 'graphql';
+import { useMutation as originalUseMutation } from '@apollo/react-hooks';
+import { MutationFunctionOptions } from '@apollo/react-common';
+
+type MutateSpy = {
+  mutation: DocumentNode;
+  spy: jest.SpyInstance;
+};
+
+type OriginalUseMutation = typeof originalUseMutation;
+
+interface UseMutation extends OriginalUseMutation {
+  mutateSpies?: MutateSpy[];
+}
+
+jest.mock('@apollo/react-hooks', () => {
+  const apolloHooks = jest.requireActual('@apollo/react-hooks');
+
+  const useQuery = jest.fn(apolloHooks.useQuery);
+
+  const mutateSpies: MutateSpy[] = [];
+  const useMutation: UseMutation = jest.fn<
+    ReturnType<typeof apolloHooks.useMutation>,
+    Parameters<typeof apolloHooks.useMutation>
+  >((...args) => {
+    const result = apolloHooks.useMutation(...args);
+    mutateSpies.push({
+      mutation: args[0] as DocumentNode,
+      spy: jest.spyOn(result, '0'),
+    });
+    return result;
+  });
+  useMutation.mutateSpies = mutateSpies;
+
+  return { ...apolloHooks, useQuery, useMutation };
+});
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toHaveBeenMutatedWith(
+        mutation: DocumentNode,
+        options?: MutationFunctionOptions,
+      ): R;
+    }
+  }
+}
+
+expect.extend({
+  toHaveBeenMutatedWith(
+    useMutation: UseMutation,
+    mutation: DocumentNode,
+    options?: MutationFunctionOptions,
+  ) {
+    const allCalls = (useMutation.mutateSpies || [])
+      .filter(({ spy }) => spy.mock.calls.length > 0)
+      .flatMap(({ mutation, spy }) =>
+        spy.mock.calls.map(([options]) => ({ mutation, options: options })),
+      );
+    if (this.isNot) {
+      expect(allCalls).not.toContainEqual({ mutation, options });
+    } else {
+      expect(allCalls).toContainEqual({ mutation, options });
+    }
+
+    // This point is reached when the above assertion was successful.
+    // The test should therefore always pass, that means it needs to be
+    // `true` when used normally, and `false` when `.not` was used.
+    return { pass: !this.isNot, message: '' };
+  },
+});

--- a/package.json
+++ b/package.json
@@ -174,7 +174,8 @@
     ],
     "setupFilesAfterEnv": [
       "<rootDir>/__mock__/hideWarnings.ts",
-      "<rootDir>/__mock__/resetGlobalMockSeeds.ts"
+      "<rootDir>/__mock__/resetGlobalMockSeeds.ts",
+      "<rootDir>/__mock__/apolloHooks.ts"
     ],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"

--- a/src/components/CelebrateItem/__tests__/CelebrateItem.tsx
+++ b/src/components/CelebrateItem/__tests__/CelebrateItem.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import * as ReactHooks from '@apollo/react-hooks';
-import { MutationResult } from '@apollo/react-common';
 import { Alert, ActionSheetIOS } from 'react-native';
 import { fireEvent } from 'react-native-testing-library';
 import MockDate from 'mockdate';
 import i18next from 'i18next';
-import { DocumentNode } from 'graphql';
+import { useMutation } from '@apollo/react-hooks';
 
 import { trackActionWithoutData } from '../../../actions/analytics';
 import { navigatePush } from '../../../actions/navigation';
@@ -34,8 +32,6 @@ MockDate.set('2019-08-21 12:00:00', 300);
 
 let onRefresh = jest.fn();
 let onClearNotification = jest.fn();
-let deleteStory = jest.fn();
-let reportStory = jest.fn();
 
 const trackActionResult = { type: 'tracked plain action' };
 const navigatePushResult = { type: 'navigate push' };
@@ -60,21 +56,8 @@ const initialState = { auth: { person: { id: myId } } };
 beforeEach(() => {
   onRefresh = jest.fn();
   onClearNotification = jest.fn();
-  deleteStory = jest.fn();
-  reportStory = jest.fn();
   (trackActionWithoutData as jest.Mock).mockReturnValue(trackActionResult);
   (navigatePush as jest.Mock).mockReturnValue(navigatePushResult);
-  jest
-    .spyOn(ReactHooks, 'useMutation')
-    .mockImplementation((input: DocumentNode) => [
-      input === DELETE_STORY
-        ? deleteStory
-        : input === REPORT_STORY
-        ? reportStory
-        : jest.fn(),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { loading: false } as MutationResult<any>,
-    ]);
 });
 
 describe('global community', () => {
@@ -258,7 +241,9 @@ describe('long-press card', () => {
           },
         ],
       );
-      expect(deleteStory).toHaveBeenCalled();
+      expect(useMutation).toHaveBeenMutatedWith(DELETE_STORY, {
+        variables: { input: { id: event.celebrateable_id } },
+      });
       expect(onRefresh).toHaveBeenCalled();
     });
   });
@@ -295,7 +280,9 @@ describe('long-press card', () => {
           },
         ],
       );
-      expect(reportStory).toHaveBeenCalled();
+      expect(useMutation).toHaveBeenMutatedWith(REPORT_STORY, {
+        variables: { subjectId: event.celebrateable_id },
+      });
     });
   });
 });

--- a/src/components/CelebrateItem/index.tsx
+++ b/src/components/CelebrateItem/index.tsx
@@ -23,6 +23,8 @@ import { Person } from '../../reducers/people';
 import { CELEBRATEABLE_TYPES } from '../../constants';
 
 import styles from './styles';
+import { DeleteStory, DeleteStoryVariables } from './__generated__/DeleteStory';
+import { ReportStory, ReportStoryVariables } from './__generated__/ReportStory';
 
 export const DELETE_STORY = gql`
   mutation DeleteStory($input: DeleteStoryInput!) {
@@ -83,8 +85,12 @@ const CelebrateItem = ({
   } = event;
 
   const { t } = useTranslation('celebrateItems');
-  const [deleteStory] = useMutation(DELETE_STORY);
-  const [reportStory] = useMutation(REPORT_STORY);
+  const [deleteStory] = useMutation<DeleteStory, DeleteStoryVariables>(
+    DELETE_STORY,
+  );
+  const [reportStory] = useMutation<ReportStory, ReportStoryVariables>(
+    REPORT_STORY,
+  );
 
   const handlePress = () =>
     dispatch(navigatePush(CELEBRATE_DETAIL_SCREEN, { event }));
@@ -107,7 +113,7 @@ const CelebrateItem = ({
         text: t('delete.buttonText'),
         onPress: async () => {
           await deleteStory({
-            variables: { input: { subjectId: celebrateable_id } },
+            variables: { input: { id: celebrateable_id } },
           });
           onRefresh();
         },

--- a/src/containers/Groups/EditStoryScreen/index.tsx
+++ b/src/containers/Groups/EditStoryScreen/index.tsx
@@ -17,6 +17,7 @@ import theme from '../../../theme';
 import { Event } from '../../../components/CelebrateItem';
 
 import styles from './styles';
+import { UpdateStory, UpdateStoryVariables } from './__generated__/UpdateStory';
 
 export const UPDATE_STORY = gql`
   mutation UpdateStory($input: UpdateStoryInput!) {
@@ -39,7 +40,9 @@ const EditStoryScreen = ({ dispatch }: EditStoryProps) => {
   const { object_description, celebrateable_id }: Event = useNavigationParam(
     'celebrationItem',
   );
-  const [updateStory] = useMutation(UPDATE_STORY);
+  const [updateStory] = useMutation<UpdateStory, UpdateStoryVariables>(
+    UPDATE_STORY,
+  );
   const [story, changeStory] = useState(object_description);
 
   const saveStory = async () => {

--- a/src/containers/Groups/ShareStoryScreen/__tests__/ShareStoryScreen.tsx
+++ b/src/containers/Groups/ShareStoryScreen/__tests__/ShareStoryScreen.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { fireEvent } from 'react-native-testing-library';
+import { useMutation } from '@apollo/react-hooks';
 
 import { navigatePush } from '../../../../actions/navigation';
 import { renderWithContext } from '../../../../../testUtils';
 
-import ShareStoryScreen from '..';
+import ShareStoryScreen, { CREATE_A_STORY } from '..';
 
 jest.mock('../../../../actions/navigation');
 const onComplete = jest.fn();
@@ -107,5 +108,14 @@ describe('Creating a story', () => {
     await fireEvent(getByTestId('StoryInput'), 'onChangeText', MOCK_STORY);
     await fireEvent.press(getByTestId('SaveStoryButton'));
     expect(onComplete).toHaveBeenCalled();
+
+    expect(useMutation).toHaveBeenMutatedWith(CREATE_A_STORY, {
+      variables: {
+        input: {
+          content: 'This is my cool story! 📘✏️',
+          organizationId: '1234',
+        },
+      },
+    });
   });
 });

--- a/src/containers/Groups/ShareStoryScreen/index.tsx
+++ b/src/containers/Groups/ShareStoryScreen/index.tsx
@@ -13,6 +13,10 @@ import theme from '../../../theme';
 import { Organization } from '../../../reducers/organizations';
 
 import styles from './styles';
+import {
+  CreateAStory,
+  CreateAStoryVariables,
+} from './__generated__/CreateAStory';
 
 export const CREATE_A_STORY = gql`
   mutation CreateAStory($input: CreateStoryInput!) {
@@ -30,7 +34,9 @@ const ShareStoryScreen = () => {
   const [story, changeStory] = useState('');
   const onComplete: () => Promise<void> = useNavigationParam('onComplete');
   const organization: Organization = useNavigationParam('organization');
-  const [createStory] = useMutation(CREATE_A_STORY);
+  const [createStory] = useMutation<CreateAStory, CreateAStoryVariables>(
+    CREATE_A_STORY,
+  );
 
   const saveStory = async () => {
     if (!story) {

--- a/src/containers/Groups/__tests__/GroupsListScreen.tsx
+++ b/src/containers/Groups/__tests__/GroupsListScreen.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { FlatList } from 'react-native';
 import { fireEvent, flushMicrotasksQueue } from 'react-native-testing-library';
 import { MockList } from 'graphql-tools';
+import { useQuery } from '@apollo/react-hooks';
 
-import GroupsListScreen from '../GroupsListScreen';
+import GroupsListScreen, { GET_COMMUNITIES_QUERY } from '../GroupsListScreen';
 import { renderWithContext } from '../../../../testUtils';
 import { navigatePush, navigateToCommunity } from '../../../actions/navigation';
 import { trackActionWithoutData } from '../../../actions/analytics';
@@ -66,6 +67,7 @@ describe('GroupsListScreen', () => {
 
     await flushMicrotasksQueue();
     snapshot();
+    expect(useQuery).toHaveBeenCalledWith(GET_COMMUNITIES_QUERY);
   });
 
   describe('card item press', () => {


### PR DESCRIPTION
- Add generated types to useMutation calls

Let me know what you guys think of this.

`useQuery` is pretty straight forward.

`useMutation` returns a mutate function which I then spy on and collect all the spies into an array. I made a custom expectation to go through all calls to any of those spies looking to see if any options arguments that matches. Let me know if you think this is flexible enough or if you see any ways to simplify it :)