### PR TITLE
Fix-GlobalTime-Mock-Add-IntrospectionFragmentMatcher

### DIFF
--- a/__mock__/globalSetup.ts
+++ b/__mock__/globalSetup.ts
@@ -1,0 +1,3 @@
+export default () => {
+  process.env.TZ = 'UTC';
+};

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
       "<rootDir>/__mock__/resetGlobalMockSeeds.ts",
       "<rootDir>/__mock__/apolloHooks.ts"
     ],
+    "globalSetup": "<rootDir>/__mock__/globalSetup.ts",
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/testUtils/apolloMockClient.ts
+++ b/testUtils/apolloMockClient.ts
@@ -1,5 +1,8 @@
 import { ApolloClient } from 'apollo-client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import {
+  InMemoryCache,
+  IntrospectionFragmentMatcher,
+} from 'apollo-cache-inmemory';
 import { SchemaLink } from 'apollo-link-schema';
 import { addMockFunctionsToSchema, IMocks } from 'graphql-tools';
 import { DocumentNode } from 'graphql';
@@ -16,13 +19,18 @@ export const createApolloMockClient = (mocks: IMocks = {}) => {
     (introspectionQuery as unknown) as IntrospectionQuery,
   );
 
+  const fragmentMatcher = new IntrospectionFragmentMatcher({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    introspectionQueryResultData: introspectionQuery as any,
+  });
+
   addMockFunctionsToSchema({
     schema,
     mocks: { ...globalMocks, ...mocks },
   });
 
   return new ApolloClient({
-    cache: new InMemoryCache(),
+    cache: new InMemoryCache({ fragmentMatcher }),
     link: new SchemaLink({ schema }),
   });
 };

--- a/testUtils/globalMocks.ts
+++ b/testUtils/globalMocks.ts
@@ -1,5 +1,6 @@
 import faker from 'faker/locale/en';
 import { IMocks } from 'graphql-tools';
+import moment from 'moment';
 
 let currentId = 1;
 const nextId = () => currentId++;
@@ -15,6 +16,9 @@ export const globalMocks: IMocks = {
   Float: () => faker.random.number({ precision: 0.01 }),
   Boolean: () => faker.random.boolean(),
   ID: () => nextId(),
+  ISO8601DateTime: () => faker.date.past(10, '2020-01-14').toUTCString(),
+  ISO8601Date: () =>
+    moment(faker.date.past(10, '2020-01-14')).format('YYYY-MM-DD'),
 
   BasePageInfo: () => ({
     endCursor: null,


### PR DESCRIPTION
This is adding the global mock for the time as well as the introspectionFragmentMatcher. This fragment matcher basically types our Apollo client. Me and Scotty based the IntrospectionFragmentMatcher on the Apollo documentation(https://www.apollographql.com/docs/react/data/fragments/).