### PR TITLE
Add yarn gql:codegen to native builds to download globalTypes.ts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
       before_script:
         - echo "TRAVIS_COMMIT=$TRAVIS_COMMIT" >> ./.env.production
         - yarn run onesky:download
+        - yarn gql:codegen
         - yarn gql:schema
       script:
         - (cd ios && fastlane ios beta)
@@ -112,6 +113,7 @@ matrix:
       before_script:
         - echo "TRAVIS_COMMIT=$TRAVIS_COMMIT" >> ./.env.production
         - yarn run onesky:download
+        - yarn gql:codegen
         - yarn gql:schema
       script:
         - (cd android && fastlane android beta)


### PR DESCRIPTION
You keep adding things that need generated GraphQL files at runtime haha. I think you used an enum from `globalTypes.ts`.

Steve ran into this and I had to [fix it in the QA CLI](https://github.com/CruGlobal/missionhub-qa-cli/commit/69341656ad7cb01c64611a943f09cdfaa204303d) and decided to fix it now for production builds.