### PR TITLE
MHP 3203 -- Fix Missing Step Counts on People Screen

### DIFF
--- a/src/components/PeopleList/__tests__/__snapshots__/PeopleList.tsx.snap
+++ b/src/components/PeopleList/__tests__/__snapshots__/PeopleList.tsx.snap
@@ -111,7 +111,7 @@ exports[`button presses arrow icon toggles collapsed sections 1`] = `
 -                     \\"__typename\\": \\"StepConnection\\",
 -                     \\"pageInfo\\": Object {
 -                       \\"__typename\\": \\"BasePageInfo\\",
--                       \\"totalCount\\": 11,
+-                       \\"totalCount\\": 9233,
 -                     },
 -                   },
 -                 }
@@ -158,7 +158,7 @@ exports[`button presses arrow icon toggles collapsed sections 1`] = `
 -                     \\"__typename\\": \\"StepConnection\\",
 -                     \\"pageInfo\\": Object {
 -                       \\"__typename\\": \\"BasePageInfo\\",
--                       \\"totalCount\\": 12812,
+-                       \\"totalCount\\": 39658,
 -                     },
 -                   },
 -                 }
@@ -205,7 +205,7 @@ exports[`button presses arrow icon toggles collapsed sections 1`] = `
 -                     \\"__typename\\": \\"StepConnection\\",
 -                     \\"pageInfo\\": Object {
 -                       \\"__typename\\": \\"BasePageInfo\\",
--                       \\"totalCount\\": 14675,
+-                       \\"totalCount\\": 39676,
 -                     },
 -                   },
 -                 }
@@ -308,7 +308,7 @@ exports[`renders correctly as Casey 1`] = `
                 "__typename": "StepConnection",
                 "pageInfo": Object {
                   "__typename": "BasePageInfo",
-                  "totalCount": 11,
+                  "totalCount": 9233,
                 },
               },
             }
@@ -334,7 +334,7 @@ exports[`renders correctly as Casey 1`] = `
                 "__typename": "StepConnection",
                 "pageInfo": Object {
                   "__typename": "BasePageInfo",
-                  "totalCount": 12812,
+                  "totalCount": 39658,
                 },
               },
             }
@@ -360,7 +360,7 @@ exports[`renders correctly as Casey 1`] = `
                 "__typename": "StepConnection",
                 "pageInfo": Object {
                   "__typename": "BasePageInfo",
-                  "totalCount": 14675,
+                  "totalCount": 39676,
                 },
               },
             }
@@ -536,7 +536,7 @@ exports[`renders correctly as Jean 1`] = `
                     "__typename": "StepConnection",
                     "pageInfo": Object {
                       "__typename": "BasePageInfo",
-                      "totalCount": 11,
+                      "totalCount": 9233,
                     },
                   },
                 }
@@ -583,7 +583,7 @@ exports[`renders correctly as Jean 1`] = `
                     "__typename": "StepConnection",
                     "pageInfo": Object {
                       "__typename": "BasePageInfo",
-                      "totalCount": 12812,
+                      "totalCount": 39658,
                     },
                   },
                 }
@@ -630,7 +630,7 @@ exports[`renders correctly as Jean 1`] = `
                     "__typename": "StepConnection",
                     "pageInfo": Object {
                       "__typename": "BasePageInfo",
-                      "totalCount": 14675,
+                      "totalCount": 39676,
                     },
                   },
                 }

--- a/src/components/PeopleList/queries.ts
+++ b/src/components/PeopleList/queries.ts
@@ -2,12 +2,16 @@ import gql from 'graphql-tag';
 
 export const GET_PEOPLE_STEPS_COUNT = gql`
   query GetPeopleStepsCount($myId: [ID!]) {
-    people(first: 1000, assignedTos: $myId) {
+    communities {
       nodes {
-        id
-        steps(completed: false) {
-          pageInfo {
-            totalCount
+        people(assignedTos: $myId) {
+          nodes {
+            id
+            steps(completed: false) {
+              pageInfo {
+                totalCount
+              }
+            }
           }
         }
       }
@@ -18,6 +22,19 @@ export const GET_PEOPLE_STEPS_COUNT = gql`
         steps(completed: false) {
           pageInfo {
             totalCount
+          }
+        }
+        contactAssignments(organizationIds: [null]) {
+          nodes {
+            person {
+              fullName
+              id
+              steps(completed: false) {
+                pageInfo {
+                  totalCount
+                }
+              }
+            }
           }
         }
       }

--- a/src/containers/PersonItem/__tests__/PersonItem.tsx
+++ b/src/containers/PersonItem/__tests__/PersonItem.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../actions/misc';
 import { navToPersonScreen } from '../../../actions/person';
 import { orgIsCru, hasOrgPermissions } from '../../../utils/common';
-import { GetPeopleStepsCount_people_nodes } from '../../../components/PeopleList/__generated__/GetPeopleStepsCount';
+import { GetPeopleStepsCount_communities_nodes_people_nodes as PersonStepCount } from '../../../components/PeopleList/__generated__/GetPeopleStepsCount';
 
 import PersonItem from '..';
 
@@ -81,7 +81,7 @@ const mockPersonWithSteps = {
   totalCount: mockStepsCount,
 };
 
-const totalStepCount: GetPeopleStepsCount_people_nodes = {
+const totalStepCount: PersonStepCount = {
   __typename: 'Person',
   id: mockPersonWithSteps.id,
   steps: {
@@ -93,7 +93,7 @@ const totalStepCount: GetPeopleStepsCount_people_nodes = {
   },
 };
 
-const noStepsCount: GetPeopleStepsCount_people_nodes = {
+const noStepsCount: PersonStepCount = {
   ...totalStepCount,
   steps: {
     __typename: 'StepConnection',

--- a/src/containers/PersonItem/index.tsx
+++ b/src/containers/PersonItem/index.tsx
@@ -25,7 +25,7 @@ import { AuthState } from '../../reducers/auth';
 import { StagesObj, StagesState } from '../../reducers/stages';
 import { Person } from '../../reducers/people';
 import { localizedStageSelector } from '../../selectors/stages';
-import { GetPeopleStepsCount_people_nodes } from '../../components/PeopleList/__generated__/GetPeopleStepsCount';
+import { GetPeopleStepsCount_communities_nodes_people_nodes as PersonStepCount } from '../../components/PeopleList/__generated__/GetPeopleStepsCount';
 
 import styles from './styles';
 
@@ -38,7 +38,7 @@ interface PersonItemProps {
   stagesObj: StagesObj;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dispatch: ThunkDispatch<any, null, never>;
-  stepsData?: GetPeopleStepsCount_people_nodes;
+  stepsData?: PersonStepCount;
 }
 
 const PersonItem = ({


### PR DESCRIPTION
The main issue was with the GQL query for fetching step counts.  In order to get personal ministry people step counts, we were doing this: 

`currentUser { contactAssignments(organizationIds: "") {}`

Apparently our API did not know how to handle an empty string for `organizationIds` and returns no results.  Spencer pushed an update to the API that allows this:

`currentUser { contactAssignments(organizationIds: [null]) {}`

With this, we can get data for personal ministry people.