### PR TITLE
MHP-3247-Reminder-Time-Fix

### DIFF
--- a/src/actions/stepReminders.ts
+++ b/src/actions/stepReminders.ts
@@ -1,5 +1,6 @@
 import { ThunkDispatch } from 'redux-thunk';
 import gql from 'graphql-tag';
+import moment from 'moment';
 
 import { DAYS_OF_THE_WEEK } from '../constants';
 import { REQUESTS } from '../api/routes';
@@ -70,7 +71,7 @@ function createAt(reminder_at: Date, reminder_type: string) {
     case ReminderTypeEnum.once:
       return reminder_at.toISOString();
     default:
-      return reminder_at.toLocaleTimeString(undefined, { hour12: false });
+      return moment(reminder_at).format('HH:mm:ss');
   }
 }
 


### PR DESCRIPTION
So me and Spencer did some debugging into the issue Steve was having when trying to create or update a step reminder. The issue was, the format of time we were sending was `9:40:00 AM` when the api is expecting `09:40:00`(the api doesn't care about the AM). What's strange is how inconsistent `.toLocaleTimeString` was being. It was working just fine for me but Steve was sending the wrong format. I reloaded my device and then it started sending the incorrect format. It seemed to be inconsistent on to which format is was sending.  I had my browser console open did the same formatting with `.localeTimeString` as we are doing in the app, with the exact same date, and got the correct formatting. But the app was logging the wrong format. There must be some formatting behind the scenes that is off or something, idk. 