### PR TITLE
MHP-3261-Challenges-Details-Not-Showing-Celebrate-Item

### DIFF
--- a/src/components/CelebrateItemContent/__tests__/CelebrateItemContent.tsx
+++ b/src/components/CelebrateItemContent/__tests__/CelebrateItemContent.tsx
@@ -17,11 +17,13 @@ import {
   COMMUNITY_PERMISSIONS_FRAGMENT,
 } from '../../../components/CelebrateItem/queries';
 import { CommunityCelebrationCelebrateableEnum } from '../../../../__generated__/globalTypes';
+import { reloadGroupChallengeFeed } from '../../../actions/challenges';
 
 import CelebrateItemContent, { CelebrateItemContentProps } from '..';
 
 jest.mock('../../../actions/analytics');
 jest.mock('../../../actions/navigation');
+jest.mock('../../../actions/challenges');
 
 const myId = '123';
 const otherId = '456';
@@ -55,10 +57,14 @@ const initialState = { auth: { person: { id: myId } } };
 
 const navigateResponse = { type: 'navigate push' };
 const trackActionResult = { type: 'tracked plain action' };
+const reloadGroupChallengeFeedReponse = { type: 'reload group feed' };
 
 beforeEach(() => {
   (trackActionWithoutData as jest.Mock).mockReturnValue(trackActionResult);
   (navigatePush as jest.Mock).mockReturnValue(navigateResponse);
+  (reloadGroupChallengeFeed as jest.Mock).mockReturnValue(
+    reloadGroupChallengeFeedReponse,
+  );
 });
 
 describe('CelebrateItemContent', () => {
@@ -258,7 +264,7 @@ describe('CelebrateItemContent', () => {
 });
 
 describe('onPressChallengeLink', () => {
-  it('navigates to challenge detail screen', () => {
+  it('navigates to challenge detail screen', async () => {
     const { getByTestId, store } = renderWithContext(
       <CelebrateItemContent
         event={{
@@ -270,12 +276,16 @@ describe('onPressChallengeLink', () => {
       />,
       { initialState },
     );
-    fireEvent.press(getByTestId('ChallengeLinkButton'));
+    await fireEvent.press(getByTestId('ChallengeLinkButton'));
 
     expect(navigatePush).toHaveBeenCalledWith(CHALLENGE_DETAIL_SCREEN, {
       challengeId: event.adjectiveAttributeValue,
       orgId: organization.id,
     });
-    expect(store.getActions()).toEqual([navigateResponse]);
+    expect(reloadGroupChallengeFeed).toHaveBeenCalledWith(organization.id);
+    expect(store.getActions()).toEqual([
+      reloadGroupChallengeFeedReponse,
+      navigateResponse,
+    ]);
   });
 });

--- a/src/components/CelebrateItemContent/index.tsx
+++ b/src/components/CelebrateItemContent/index.tsx
@@ -12,6 +12,7 @@ import {
   GLOBAL_COMMUNITY_ID,
 } from '../../constants';
 import { navigatePush } from '../../actions/navigation';
+import { reloadGroupChallengeFeed } from '../../actions/challenges';
 import { CHALLENGE_DETAIL_SCREEN } from '../../containers/ChallengeDetailScreen';
 import { getFirstNameAndLastInitial } from '../../utils/common';
 import { GetCelebrateFeed_community_celebrationItems_nodes as CelebrateItem } from '../../containers/CelebrateFeed/__generated__/GetCelebrateFeed';
@@ -66,10 +67,11 @@ const CelebrateItemContent = ({
     ? subjectPersonName
     : t('aMissionHubUser');
 
-  const onPressChallengeLink = () => {
+  const onPressChallengeLink = async () => {
     const orgId = organization.id;
     const challengeId = adjectiveAttributeValue;
     if (orgId && orgId !== GLOBAL_COMMUNITY_ID) {
+      await dispatch(reloadGroupChallengeFeed(orgId));
       dispatch(
         navigatePush(CHALLENGE_DETAIL_SCREEN, {
           challengeId,


### PR DESCRIPTION
So when the app first loads, we aren't loading the challenges for a given community until they navigate to the challenge feed. This is an issue when they click the celebrate item challenge link as redux has no challenges loaded, so no details for that challenge load. So I just made it to where it reloads the challenge feed for that community if they click the link to guarantee the data will exist/be updated. 