### PR TITLE
Improve-CelebrationScreen-Test

### DIFF
--- a/src/containers/CelebrationScreen/__tests__/CelebrationScreen.tsx
+++ b/src/containers/CelebrationScreen/__tests__/CelebrationScreen.tsx
@@ -21,9 +21,32 @@ navigateReset.mockReturnValue({ type: 'navigated reset' });
 // @ts-ignore
 navigateToMainTabs.mockReturnValue({ type: 'navigateToMainTabs' });
 
-it('renders correctly', () => {
+it('renders random gif correctly', () => {
   // @ts-ignore
   renderWithContext(<CelebrationScreen />).snapshot();
+});
+
+describe('renders different gifs correctly', () => {
+  it('renders arrow gif', () => {
+    // @ts-ignore
+    renderWithContext(<CelebrationScreen gifId={0} />).snapshot();
+  });
+  it('renders dino gif', () => {
+    // @ts-ignore
+    renderWithContext(<CelebrationScreen gifId={1} />).snapshot();
+  });
+  it('renders fireworks gif', () => {
+    // @ts-ignore
+    renderWithContext(<CelebrationScreen gifId={2} />).snapshot();
+  });
+  it('renders narwhal gif', () => {
+    // @ts-ignore
+    renderWithContext(<CelebrationScreen gifId={3} />).snapshot();
+  });
+  it('renders party gif', () => {
+    // @ts-ignore
+    renderWithContext(<CelebrationScreen gifId={4} />).snapshot();
+  });
 });
 
 describe('celebration screen methods', () => {

--- a/src/containers/CelebrationScreen/__tests__/__snapshots__/CelebrationScreen.tsx.snap
+++ b/src/containers/CelebrationScreen/__tests__/__snapshots__/CelebrationScreen.tsx.snap
@@ -1,6 +1,176 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`renders different gifs correctly renders arrow gif 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#52C5DC",
+      },
+      Object {
+        "flex": 1,
+        "justifyContent": "center",
+      },
+    ]
+  }
+>
+  <Image
+    onLoad={[Function]}
+    resizeMode="contain"
+    source={
+      Object {
+        "testUri": "../../../src/containers/CelebrationScreen/gifs/ArrowWhite.gif",
+      }
+    }
+    style={
+      Object {
+        "flex": 1,
+        "height": 1334,
+        "width": 750,
+      }
+    }
+    testID="gif"
+  />
+</View>
+`;
+
+exports[`renders different gifs correctly renders dino gif 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#52C5DC",
+      },
+      Object {
+        "flex": 1,
+        "justifyContent": "center",
+      },
+    ]
+  }
+>
+  <Image
+    onLoad={[Function]}
+    resizeMode="contain"
+    source={
+      Object {
+        "testUri": "../../../src/containers/CelebrationScreen/gifs/DinoWhite.gif",
+      }
+    }
+    style={
+      Object {
+        "flex": 1,
+        "height": 1334,
+        "width": 750,
+      }
+    }
+    testID="gif"
+  />
+</View>
+`;
+
+exports[`renders different gifs correctly renders fireworks gif 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#52C5DC",
+      },
+      Object {
+        "flex": 1,
+        "justifyContent": "center",
+      },
+    ]
+  }
+>
+  <Image
+    onLoad={[Function]}
+    resizeMode="contain"
+    source={
+      Object {
+        "testUri": "../../../src/containers/CelebrationScreen/gifs/FireworksWhite.gif",
+      }
+    }
+    style={
+      Object {
+        "flex": 1,
+        "height": 1334,
+        "width": 750,
+      }
+    }
+    testID="gif"
+  />
+</View>
+`;
+
+exports[`renders different gifs correctly renders narwhal gif 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#52C5DC",
+      },
+      Object {
+        "flex": 1,
+        "justifyContent": "center",
+      },
+    ]
+  }
+>
+  <Image
+    onLoad={[Function]}
+    resizeMode="contain"
+    source={
+      Object {
+        "testUri": "../../../src/containers/CelebrationScreen/gifs/NarwhalWhite.gif",
+      }
+    }
+    style={
+      Object {
+        "flex": 1,
+        "height": 1334,
+        "width": 750,
+      }
+    }
+    testID="gif"
+  />
+</View>
+`;
+
+exports[`renders different gifs correctly renders party gif 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#52C5DC",
+      },
+      Object {
+        "flex": 1,
+        "justifyContent": "center",
+      },
+    ]
+  }
+>
+  <Image
+    onLoad={[Function]}
+    resizeMode="contain"
+    source={
+      Object {
+        "testUri": "../../../src/containers/CelebrationScreen/gifs/PartyWhite.gif",
+      }
+    }
+    style={
+      Object {
+        "flex": 1,
+        "height": 1334,
+        "width": 750,
+      }
+    }
+    testID="gif"
+  />
+</View>
+`;
+
+exports[`renders random gif correctly 1`] = `
 <View
   style={
     Array [


### PR DESCRIPTION
So I was getting tired of code coverage failing because one of the gifs on the celebrations screen wouldn't get covered because we are randomly selecting gifs. A restart of the travis build would fix this but it just feels like a waste of time to have to do that.
<img width="996" alt="Screen Shot 2020-03-19 at 2 19 21 PM" src="https://user-images.githubusercontent.com/39680460/77101167-42f8f900-69ed-11ea-89bc-cddeb2c8c47e.png">
So I just made tests to snapshot each gif individually to make sure it gets tested. Let me know what you think.
