### PR TITLE
MHP-3213 - Auth token still exists after logging out

### DIFF
--- a/src/reducers/__tests__/auth.ts
+++ b/src/reducers/__tests__/auth.ts
@@ -1,4 +1,4 @@
-import auth from '../auth';
+import auth, { AuthState } from '../auth';
 import { REQUESTS } from '../../api/routes';
 import {
   CLEAR_UPGRADE_TOKEN,
@@ -10,7 +10,7 @@ import * as common from '../../utils/common';
 
 const token = 'asdfasndfiosdc';
 const personId = '123456';
-const initialState = {
+const initialState: Partial<AuthState> = {
   person: {},
 };
 
@@ -74,6 +74,16 @@ it('sets new token after refreshing anonymous login', () => {
   });
 
   expect(state).toEqual({ ...initialState, token });
+});
+
+it('does not set new token after refreshing anonymous login if user is logged out', () => {
+  const state = auth(
+    // @ts-ignore
+    { ...initialState, token: '' },
+    { type: REQUESTS.REFRESH_ANONYMOUS_LOGIN.SUCCESS, results: { token } },
+  );
+
+  expect(state).toEqual({ ...initialState, token: '' });
 });
 
 it('sets isJean after loading me', () => {
@@ -166,6 +176,19 @@ it('updates a user token', () => {
   );
 
   expect(state).toEqual({ token });
+});
+
+it('does not update a user token if the user has already logged out', () => {
+  const state = auth(
+    // @ts-ignore
+    { token: '' },
+    {
+      token,
+      type: UPDATE_TOKEN,
+    },
+  );
+
+  expect(state).toEqual({ token: '' });
 });
 
 it("should clear the user's upgradeToken", () => {

--- a/src/reducers/auth.ts
+++ b/src/reducers/auth.ts
@@ -72,6 +72,10 @@ function authReducer(state = initialAuthState, action: any) {
         },
       };
     case REQUESTS.REFRESH_ANONYMOUS_LOGIN.SUCCESS:
+      // If an API call is slow and then FAILS, we refresh the anon login token. If a user logs out while that is happening, they could get stuck in an online state.
+      if (state.token === '') {
+        return state;
+      }
       return {
         ...state,
         token: results.token,
@@ -119,6 +123,10 @@ function authReducer(state = initialAuthState, action: any) {
         },
       };
     case UPDATE_TOKEN:
+      // If an API call is slow and then finishes after a user logs out, it would cause the user to be stuck in an online state. This will prevent that state from happening.
+      if (state.token === '') {
+        return state;
+      }
       return {
         ...state,
         token: action.token,


### PR DESCRIPTION
Don't change user token if user is logged out.
This can occur if there is a slow API call and the user logs out within the time that it is happening.