### PR TITLE
MHP-3187 - Fix android notes to not be hidden.

### DIFF
--- a/src/containers/ContactNotes/__tests__/__snapshots__/ContactNotes.tsx.snap
+++ b/src/containers/ContactNotes/__tests__/__snapshots__/ContactNotes.tsx.snap
@@ -501,9 +501,11 @@ exports[`contact notes notes are shown 1`] = `
         "bottom": 90,
       }
     }
+    persistentScrollbar={true}
     style={
       Object {
         "flex": 1,
+        "marginBottom": undefined,
       }
     }
   >
@@ -517,14 +519,17 @@ exports[`contact notes notes are shown 1`] = `
             Object {
               "fontFamily": "SourceSansPro-Regular",
             },
-            Object {
-              "borderBottomWidth": 0,
-              "color": "#505256",
-              "fontSize": 16,
-              "marginTop": 30,
-              "paddingHorizontal": 36,
-              "textAlign": "left",
-            },
+            Array [
+              Object {
+                "borderBottomWidth": 0,
+                "color": "#505256",
+                "fontSize": 16,
+                "marginTop": 30,
+                "paddingHorizontal": 36,
+                "textAlign": "left",
+              },
+              null,
+            ],
           ]
         }
       >
@@ -617,8 +622,8 @@ exports[`contact notes press bottom button saves and switches to not editing sta
 - First value
 + Second value
 
-@@ -17,33 +17,18 @@
-          \\"flex\\": 1,
+@@ -19,47 +19,35 @@
+          \\"marginBottom\\": undefined,
         }
       }
     >
@@ -638,27 +643,30 @@ exports[`contact notes press bottom button saves and switches to not editing sta
 +       <Text
           style={
             Array [
++             Object {
++               \\"color\\": \\"#505256\\",
++             },
               Object {
 -               \\"backgroundColor\\": \\"transparent\\",
 -               \\"borderBottomColor\\": \\"#52C5DC\\",
 -               \\"borderBottomWidth\\": 1,
 -               \\"color\\": \\"#ffffff\\",
-+               \\"color\\": \\"#505256\\",
-+             },
-+             Object {
                 \\"fontFamily\\": \\"SourceSansPro-Regular\\",
 -               \\"fontSize\\": 16,
 -               \\"letterSpacing\\": 0.25,
 -               \\"paddingVertical\\": 5,
               },
-              Object {
-                \\"borderBottomWidth\\": 0,
-                \\"color\\": \\"#505256\\",
-                \\"fontSize\\": 16,
-@@ -51,13 +36,13 @@
-                \\"paddingHorizontal\\": 36,
-                \\"textAlign\\": \\"left\\",
-              },
++             Array [
+                Object {
+                  \\"borderBottomWidth\\": 0,
+                  \\"color\\": \\"#505256\\",
+                  \\"fontSize\\": 16,
+                  \\"marginTop\\": 30,
+                  \\"paddingHorizontal\\": 36,
+                  \\"textAlign\\": \\"left\\",
+                },
++               null,
++             ],
             ]
           }
 -         underlineColorAndroid=\\"rgba(0,0,0,0)\\"
@@ -672,7 +680,7 @@ exports[`contact notes press bottom button saves and switches to not editing sta
     <RCTSafeAreaView
       emulateUnlessSupported={true}
       style={
-@@ -128,11 +113,11 @@
+@@ -130,11 +118,11 @@
                   Object {},
                 ],
               ]
@@ -692,8 +700,8 @@ exports[`contact notes press bottom button switches to editing state 1`] = `
 - First value
 + Second value
 
-@@ -17,18 +17,33 @@
-          \\"flex\\": 1,
+@@ -19,35 +19,47 @@
+          \\"marginBottom\\": undefined,
         }
       }
     >
@@ -713,10 +721,10 @@ exports[`contact notes press bottom button switches to editing state 1`] = `
 +         selectionColor=\\"#005A7F\\"
           style={
             Array [
-              Object {
+-             Object {
 -               \\"color\\": \\"#505256\\",
 -             },
--             Object {
+              Object {
 +               \\"backgroundColor\\": \\"transparent\\",
 +               \\"borderBottomColor\\": \\"#52C5DC\\",
 +               \\"borderBottomWidth\\": 1,
@@ -726,14 +734,17 @@ exports[`contact notes press bottom button switches to editing state 1`] = `
 +               \\"letterSpacing\\": 0.25,
 +               \\"paddingVertical\\": 5,
               },
+-             Array [
               Object {
                 \\"borderBottomWidth\\": 0,
                 \\"color\\": \\"#505256\\",
                 \\"fontSize\\": 16,
-@@ -36,13 +51,13 @@
+                \\"marginTop\\": 30,
                 \\"paddingHorizontal\\": 36,
                 \\"textAlign\\": \\"left\\",
               },
+-               null,
+-             ],
             ]
           }
 -       >
@@ -747,7 +758,7 @@ exports[`contact notes press bottom button switches to editing state 1`] = `
     <RCTSafeAreaView
       emulateUnlessSupported={true}
       style={
-@@ -113,11 +128,11 @@
+@@ -118,11 +130,11 @@
                   Object {},
                 ],
               ]

--- a/src/containers/ContactNotes/index.tsx
+++ b/src/containers/ContactNotes/index.tsx
@@ -19,6 +19,7 @@ import { ANALYTICS_ASSIGNMENT_TYPE } from '../../constants';
 import { Person } from '../../reducers/people';
 import { AuthState } from '../../reducers/auth';
 import { Organization } from '../../reducers/organizations';
+import { isAndroid } from '../../utils/common';
 
 import styles from './styles';
 
@@ -91,7 +92,12 @@ const ContactNotes = ({
   };
 
   const renderNotes = () => (
-    <ScrollView style={{ flex: 1 }} contentInset={{ bottom: 90 }}>
+    <ScrollView
+      style={{ flex: 1, marginBottom: isAndroid && editing ? 80 : undefined }}
+      contentInset={{ bottom: 90 }}
+      // @ts-ignore
+      persistentScrollbar={true}
+    >
       {editing ? (
         <Input
           ref={notesInput}
@@ -105,7 +111,11 @@ const ContactNotes = ({
           autoCorrect={true}
         />
       ) : (
-        <Text style={styles.notesText}>{text}</Text>
+        <Text
+          style={[styles.notesText, isAndroid ? { paddingBottom: 80 } : null]}
+        >
+          {text}
+        </Text>
       )}
     </ScrollView>
   );


### PR DESCRIPTION
@reldredge71 I noticed your comments about not being able to keep the editing cursor above the bottom button.

The solution I implemented here allows the user to see the not behind the button like normal, but then when they go into editing mode, it gets cut off behind the button. This way the cursor stays above the button, even if they're not editing the bottom of the note. Android does not have the contentInsets property that the iOS scroll view is using.