### PR TITLE
Pass callback to appsFlyer.setCustomerUserId to fix error when missin…

### DIFF
--- a/src/actions/auth/userData.ts
+++ b/src/actions/auth/userData.ts
@@ -52,7 +52,7 @@ export function authSuccess() {
 
     const mePerson = await dispatch(getMe('contact_assignments'));
     RNOmniture.syncIdentifier(mePerson.global_registry_mdm_id);
-    appsFlyer.setCustomerUserId(mePerson.global_registry_mdm_id);
+    appsFlyer.setCustomerUserId(mePerson.global_registry_mdm_id, () => {});
 
     dispatch({
       type: LOAD_PERSON_DETAILS,


### PR DESCRIPTION
…g second argument

Their types are wrong. Apparently a function is actually required... Might make a issue for them.

I fixed this one other place (that I just pushed without code review since it seemed trivial and I was trying to get a build out). 7283f2caeb75cbcc5b2f8535164370e2979b9bae Maybe you could review that too.

https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/147