### PR TITLE
Fix PopupMenu children proptype

### DIFF
--- a/src/components/PopupMenu/index.android.tsx
+++ b/src/components/PopupMenu/index.android.tsx
@@ -90,7 +90,10 @@ PopupMenu.propTypes = {
       onPress: PropTypes.func.isRequired,
     }),
   ).isRequired,
-  children: PropTypes.element,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.element),
+    PropTypes.element,
+  ]),
   disabled: PropTypes.bool,
   triggerOnLongPress: PropTypes.bool,
   buttonProps: PropTypes.object,

--- a/src/components/PopupMenu/index.ios.tsx
+++ b/src/components/PopupMenu/index.ios.tsx
@@ -92,7 +92,10 @@ PopupMenu.propTypes = {
       destructive: PropTypes.bool,
     }),
   ).isRequired,
-  children: PropTypes.element,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.element),
+    PropTypes.element,
+  ]),
   disabled: PropTypes.bool,
   triggerOnLongPress: PropTypes.bool,
   title: PropTypes.string,


### PR DESCRIPTION
I was getting this and decided to fix it... It's only a PropTypes warning, not an actual bug. Still annoying in development though.
<img width="939" alt="Screen Shot 2020-04-09 at 10 16 09 AM" src="https://user-images.githubusercontent.com/756501/78923411-0731dc00-7a4d-11ea-9938-c55ab405c367.png">
