### PR TITLE
MHP-3192-Close-SideMenu-After-Editing

### DIFF
--- a/src/containers/AddContactScreen/__tests__/AddContactScreen.tsx
+++ b/src/containers/AddContactScreen/__tests__/AddContactScreen.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Alert, ActionSheetIOS } from 'react-native';
 import { fireEvent, flushMicrotasksQueue } from 'react-native-testing-library';
 import { useQuery, useMutation } from '@apollo/react-hooks';
+import { DrawerActions } from 'react-navigation-drawer';
 
 import { renderWithContext } from '../../../../testUtils';
 import { useAnalytics } from '../../../utils/hooks/useAnalytics';
@@ -29,6 +30,7 @@ jest.mock('../../../actions/navigation');
 jest.mock('../../../actions/person');
 jest.mock('../../../utils/hooks/useAnalytics');
 jest.mock('../../../utils/hooks/useIsMe');
+jest.mock('react-navigation-drawer');
 
 const me = { id: '99' };
 const contactId = '23';
@@ -54,6 +56,7 @@ const loadPersonResults = {
   type: LOAD_PERSON_DETAILS,
 };
 const getPersonDetailsResults = { type: 'get person details' };
+const closeDrawerResults = { type: 'drawer closed' };
 const next = jest.fn();
 
 const initialState = {
@@ -69,6 +72,7 @@ beforeEach(() => {
   (useIsMe as jest.Mock).mockReturnValue(false);
   (getPersonDetails as jest.Mock).mockReturnValue(getPersonDetailsResults);
   next.mockReturnValue(nextResponse);
+  (DrawerActions.closeDrawer as jest.Mock).mockReturnValue(closeDrawerResults);
   Alert.alert = jest.fn();
 });
 
@@ -220,10 +224,12 @@ describe('savePerson', () => {
           didSavePerson: true,
           isMe: false,
         });
+        expect(DrawerActions.closeDrawer).toHaveBeenLastCalledWith();
 
         expect(store.getActions()).toEqual([
           loadPersonResults,
           trackActionResponse,
+          closeDrawerResults,
           nextResponse,
         ]);
         expect(useAnalytics).toHaveBeenCalledWith(['people', 'add']);
@@ -283,10 +289,12 @@ describe('savePerson', () => {
           didSavePerson: true,
           isMe: false,
         });
+        expect(DrawerActions.closeDrawer).toHaveBeenLastCalledWith();
 
         expect(store.getActions()).toEqual([
           loadPersonResults,
           trackActionResponse,
+          closeDrawerResults,
           nextResponse,
         ]);
       });
@@ -356,9 +364,11 @@ describe('savePerson', () => {
           didSavePerson: true,
           isMe: false,
         });
+        expect(DrawerActions.closeDrawer).toHaveBeenLastCalledWith();
 
         expect(store.getActions()).toEqual([
           getPersonDetailsResults,
+          closeDrawerResults,
           nextResponse,
         ]);
       });
@@ -412,9 +422,11 @@ describe('savePerson', () => {
           didSavePerson: true,
           isMe: false,
         });
+        expect(DrawerActions.closeDrawer).toHaveBeenLastCalledWith();
 
         expect(store.getActions()).toEqual([
           getPersonDetailsResults,
+          closeDrawerResults,
           nextResponse,
         ]);
       });
@@ -515,9 +527,11 @@ describe('savePerson', () => {
           didSavePerson: true,
           isMe: false,
         });
+        expect(DrawerActions.closeDrawer).toHaveBeenLastCalledWith();
 
         expect(store.getActions()).toEqual([
           getPersonDetailsResults,
+          closeDrawerResults,
           nextResponse,
         ]);
       });

--- a/src/containers/AddContactScreen/index.tsx
+++ b/src/containers/AddContactScreen/index.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useMutation } from '@apollo/react-hooks';
 import { ThunkAction } from 'redux-thunk';
 import { AnyAction } from 'redux';
+import { DrawerActions } from 'react-navigation-drawer';
 
 import BottomButton from '../../components/BottomButton';
 import Header from '../../components/Header';
@@ -99,6 +100,8 @@ const AddContactScreen = ({ next }: AddContactScreenProps) => {
   >(UPDATE_PERSON);
 
   const complete = (didSavePerson: boolean, person?: PersonType) => {
+    // Close sidemenu so we land on person screen with it not opened
+    dispatch(DrawerActions.closeDrawer());
     dispatch(
       next({
         personId: person?.id,

--- a/src/routes/editPerson/__tests__/editPersonFlow.tsx
+++ b/src/routes/editPerson/__tests__/editPersonFlow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useMutation } from '@apollo/react-hooks';
 import { fireEvent, flushMicrotasksQueue } from 'react-native-testing-library';
+import { DrawerActions } from 'react-navigation-drawer';
 
 import { ADD_CONTACT_SCREEN } from '../../../containers/AddContactScreen';
 import { EditPersonFlowScreens } from '../editPersonFlow';
@@ -25,6 +26,7 @@ jest.mock('../../../utils/hooks/useIsMe');
 jest.mock('../../../actions/selectStage');
 jest.mock('../../../actions/stages');
 jest.mock('react-native-device-info');
+jest.mock('react-navigation-drawer');
 
 const me = { id: '1' };
 const next = jest.fn();
@@ -34,6 +36,7 @@ const getPersonDetailsResponse = { type: 'get person details' };
 const trackActionResponse = { type: 'track action' };
 const trackScreenChangeResponse = { type: 'track screen change' };
 const selectPersonStageResult = { type: 'update select person stage' };
+const closeDrawerResults = { type: 'drawer closed' };
 
 const baseStage: Stage = {
   id: '1',
@@ -79,6 +82,7 @@ beforeEach(() => {
   (getPersonDetails as jest.Mock).mockReturnValue(getPersonDetailsResponse);
   (selectPersonStage as jest.Mock).mockReturnValue(selectPersonStageResult);
   (next as jest.Mock).mockReturnValue({ type: 'next' });
+  (DrawerActions.closeDrawer as jest.Mock).mockReturnValue(closeDrawerResults);
 });
 
 describe('AddContactScreen next', () => {
@@ -99,7 +103,10 @@ describe('AddContactScreen next', () => {
 
     await fireEvent.press(getByTestId('backIcon'));
     expect(navigateBack).toHaveBeenCalledWith();
-    expect(store.getActions()).toEqual([navigateBackResponse]);
+    expect(store.getActions()).toEqual([
+      closeDrawerResults,
+      navigateBackResponse,
+    ]);
   });
 
   it('navigates back if edited and current user is the one being edited', async () => {
@@ -147,6 +154,7 @@ describe('AddContactScreen next', () => {
     expect(navigateBack).toHaveBeenCalledWith();
     expect(store.getActions()).toEqual([
       getPersonDetailsResponse,
+      closeDrawerResults,
       navigateBackResponse,
     ]);
   });
@@ -193,6 +201,7 @@ describe('AddContactScreen next', () => {
     expect(navigateBack).toHaveBeenCalledWith();
     expect(store.getActions()).toEqual([
       getPersonDetailsResponse,
+      closeDrawerResults,
       navigateBackResponse,
     ]);
   });


### PR DESCRIPTION
Steve wanted the SideMenu to close after editing someone so we would just land back on the person screen.