### PR TITLE
Use bundle exec to run pod version installed by bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:c": "npm run test:coverage",
     "test:s": "npm run test:snapshot",
     "ios": "react-native run-ios",
-    "ios:pod": "cd ios && pod install",
+    "ios:pod": "cd ios && bundle exec pod install",
     "lint": "eslint './*.{js,ts,tsx}' './{src,testUtils}/**/*.{js,ts,tsx}'",
     "lint:fix": "eslint './*.{js,ts,tsx}' './{src,testUtils}/**/*.{js,ts,tsx}' --fix",
     "lint:ts": "tsc",


### PR DESCRIPTION
I upgraded my ruby version after it was breaking after running `brew upgrade`. This helps it pick up the version that was installed with `bundle install` instead of a global version.