### PR TITLE
Revert "Add support for FeedItemComment in content report screens"

### DIFF
--- a/src/containers/CommentItem/index.tsx
+++ b/src/containers/CommentItem/index.tsx
@@ -48,14 +48,14 @@ const CommentItem = ({
     editingStyle,
     name: nameStyle,
   } = styles;
-  const isMine = person?.id === me.id || author?.id === me.id;
+  const isMine = person ? person.id === me.id : author.id === me.id;
   const isMineNotReported = isMine && !isReported;
   const itemDate = created_at ? created_at : createdAt ? createdAt : '';
   const name = person
     ? person.first_name
       ? `${person.first_name} ${person.last_name}`
       : person.fullName
-    : author?.fullName;
+    : author.fullName;
 
   const renderContent = () => {
     return (

--- a/src/containers/Groups/GroupReport.tsx
+++ b/src/containers/Groups/GroupReport.tsx
@@ -70,12 +70,12 @@ export const GET_REPORTED_CONTENT = gql`
                 firstName
               }
             }
-            ... on FeedItemComment {
+            ... on Post {
               id
               content
               createdAt
               updatedAt
-              person {
+              author {
                 id
                 fullName
                 firstName

--- a/src/containers/ReportedItem/index.tsx
+++ b/src/containers/ReportedItem/index.tsx
@@ -59,7 +59,6 @@ const ReportedItem = ({
     switch (type) {
       case 'Story':
         return 'storyBy';
-      case 'FeedItemComment':
       case 'CommunityCelebrationItemComment':
         return 'commentBy';
       default:
@@ -96,8 +95,7 @@ const ReportedItem = ({
   const commentBy =
     subject.__typename === 'Story' || subject.__typename === 'Post'
       ? subject.author.fullName
-      : subject.__typename === 'CommunityCelebrationItemComment' ||
-        subject.__typename === 'FeedItemComment'
+      : subject.__typename === 'CommunityCelebrationItemComment'
       ? subject.person.fullName
       : '';
   const { card, users, comment, buttonLeft, buttonRight } = styles;


### PR DESCRIPTION
Reverts CruGlobal/missionhub-react-native#1677

This breaks clients until the API part is deployed. We were hoping for a more graceful transition. I think since you've deleted the user facing reported content notification in the feature branch, we can ignore some of the errors with trying to reuse screens there for a bit and fix things up later. I think the API for loading all content reports across communities will be different. I'm just moving this through to get a build going tonight with the locale fixes.