### PR TITLE
Revert "Revert "Add support for FeedItemComment in content report screens""

### DIFF
--- a/src/containers/CommentItem/index.tsx
+++ b/src/containers/CommentItem/index.tsx
@@ -48,14 +48,14 @@ const CommentItem = ({
     editingStyle,
     name: nameStyle,
   } = styles;
-  const isMine = person ? person.id === me.id : author.id === me.id;
+  const isMine = person?.id === me.id || author?.id === me.id;
   const isMineNotReported = isMine && !isReported;
   const itemDate = created_at ? created_at : createdAt ? createdAt : '';
   const name = person
     ? person.first_name
       ? `${person.first_name} ${person.last_name}`
       : person.fullName
-    : author.fullName;
+    : author?.fullName;
 
   const renderContent = () => {
     return (

--- a/src/containers/Groups/GroupReport.tsx
+++ b/src/containers/Groups/GroupReport.tsx
@@ -70,12 +70,12 @@ export const GET_REPORTED_CONTENT = gql`
                 firstName
               }
             }
-            ... on Post {
+            ... on FeedItemComment {
               id
               content
               createdAt
               updatedAt
-              author {
+              person {
                 id
                 fullName
                 firstName

--- a/src/containers/ReportedItem/index.tsx
+++ b/src/containers/ReportedItem/index.tsx
@@ -59,6 +59,7 @@ const ReportedItem = ({
     switch (type) {
       case 'Story':
         return 'storyBy';
+      case 'FeedItemComment':
       case 'CommunityCelebrationItemComment':
         return 'commentBy';
       default:
@@ -95,7 +96,8 @@ const ReportedItem = ({
   const commentBy =
     subject.__typename === 'Story' || subject.__typename === 'Post'
       ? subject.author.fullName
-      : subject.__typename === 'CommunityCelebrationItemComment'
+      : subject.__typename === 'CommunityCelebrationItemComment' ||
+        subject.__typename === 'FeedItemComment'
       ? subject.person.fullName
       : '';
   const { card, users, comment, buttonLeft, buttonRight } = styles;


### PR DESCRIPTION
Reverts CruGlobal/missionhub-react-native#1680

It's back from the dead and seems to work as is. The problem before is Spencer broke old apps with the API change so we were less aggressive there. His API change needs to go to prod before this does. I didn't want this going out with the last locale release since the API wasn't ready. https://github.com/CruGlobal/missionhub-api/pull/1422