### PR TITLE
Fix-Apollo-Refetch-Error

### DIFF
--- a/src/containers/CelebrateFeedPostCards/index.tsx
+++ b/src/containers/CelebrateFeedPostCards/index.tsx
@@ -97,7 +97,6 @@ export const CelebrateFeedPostCards = ({
     MarkCommunityFeedItemsRead,
     MarkCommunityFeedItemsReadVariables
   >(MARK_COMMUNITY_FEED_ITEMS_READ, {
-    awaitRefetchQueries: true,
     refetchQueries: (data: MarkCommunityFeedItemsRead) =>
       data.markCommunityFeedItemsAsRead?.community?.id
         ? [


### PR DESCRIPTION
So I got the error to go away by adding this but I was hoping to also remove the refetch that gets passed down from the parent component. The issue is, we also need the variables to run the refetch so we would need to pass those down.. which defeats the purpose of removing the refetch being passed haha.