### PR TITLE
MHP-3361: Remove isJean from codebase

### DIFF
--- a/src/actions/__tests__/notifications.ts
+++ b/src/actions/__tests__/notifications.ts
@@ -471,7 +471,6 @@ describe('askNotificationPermissions', () => {
 
     const store = createThunkStore({
       auth: {
-        isJean: true,
         person,
       },
       organizations,

--- a/src/actions/__tests__/people.ts
+++ b/src/actions/__tests__/people.ts
@@ -45,7 +45,6 @@ describe('getMyPeople', () => {
     });
     store = mockStore({
       auth: {
-        isJean: false,
         person: mockUser,
       },
     });

--- a/src/actions/__tests__/person.ts
+++ b/src/actions/__tests__/person.ts
@@ -29,7 +29,7 @@ import {
 } from '../person';
 import callApi from '../api';
 import { REQUESTS } from '../../api/routes';
-import { trackActionWithoutData, setAnalyticsMinistryMode } from '../analytics';
+import { trackActionWithoutData } from '../analytics';
 import { navigatePush } from '../navigation';
 import { getMyCommunities } from '../organizations';
 import { PeopleState } from '../../reducers/people';
@@ -88,13 +88,9 @@ beforeEach(() => {
 
 describe('get me', () => {
   const action = { type: 'got me' };
-  const setMinistryModeResult = { type: 'set ministry mode' };
 
   beforeEach(() => {
     (callApi as jest.Mock).mockReturnValue(action);
-    (setAnalyticsMinistryMode as jest.Mock).mockReturnValue(
-      setMinistryModeResult,
-    );
   });
 
   it('should get me', async () => {
@@ -104,9 +100,8 @@ describe('get me', () => {
     expect(callApi).toHaveBeenCalledWith(REQUESTS.GET_ME, {
       include: expectedInclude,
     });
-    expect(setAnalyticsMinistryMode).toHaveBeenCalledWith();
     // @ts-ignore
-    expect(store.getActions()).toEqual([action, setMinistryModeResult]);
+    expect(store.getActions()).toEqual([action]);
   });
 
   it('should add extra include', () => {

--- a/src/actions/analytics.ts
+++ b/src/actions/analytics.ts
@@ -23,14 +23,12 @@ import {
   ANALYTICS_ASSIGNMENT_TYPE,
   ANALYTICS_EDIT_MODE,
   ANALYTICS_PERMISSION_TYPE,
-  ANALYTICS_MINISTRY_MODE,
   LOGGED_IN,
   NOT_LOGGED_IN,
   //ID_SCHEMA,
 } from '../constants';
 import { AnalyticsState } from '../reducers/analytics';
 import { AuthState } from '../reducers/auth';
-import { userIsJean } from '../utils/common';
 
 import { StepAddedAnalytics } from './__generated__/StepAddedAnalytics';
 
@@ -51,7 +49,6 @@ export interface TrackStateContext {
   [ANALYTICS_ASSIGNMENT_TYPE]: 'self' | 'contact' | 'community member' | '';
   [ANALYTICS_EDIT_MODE]: 'set' | 'update' | '';
   [ANALYTICS_PERMISSION_TYPE]: 'owner' | 'member' | 'admin' | '';
-  [ANALYTICS_MINISTRY_MODE]: boolean;
 }
 
 export interface ScreenContext {
@@ -62,19 +59,6 @@ export interface ScreenContext {
 }
 
 export const ANALYTICS_CONTEXT_CHANGED = 'ANALYTICS_CONTEXT_CHANGED';
-
-export const setAnalyticsMinistryMode = () => (
-  dispatch: ThunkDispatch<{}, {}, AnyAction>,
-  getState: () => { auth: AuthState },
-) => {
-  const authPersonPermissions = getState().auth.person
-    .organizational_permissions;
-  dispatch(
-    updateAnalyticsContext({
-      [ANALYTICS_MINISTRY_MODE]: userIsJean(authPersonPermissions),
-    }),
-  );
-};
 
 export const trackScreenChange = (
   screenName: string | string[],

--- a/src/actions/person.ts
+++ b/src/actions/person.ts
@@ -22,7 +22,7 @@ import {
 import { personSelector, contactAssignmentSelector } from '../selectors/people';
 
 import callApi from './api';
-import { trackActionWithoutData, setAnalyticsMinistryMode } from './analytics';
+import { trackActionWithoutData } from './analytics';
 import { navigatePush } from './navigation';
 import { getMyCommunities } from './organizations';
 
@@ -39,8 +39,6 @@ export const getMe = (extraInclude?: string) => async (
   const { response: person } = await dispatch(
     callApi(REQUESTS.GET_ME, { include }),
   );
-
-  dispatch(setAnalyticsMinistryMode());
 
   return person;
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -118,7 +118,6 @@ export const ANALYTICS_SECTION_TYPE = 'cru.section-type';
 export const ANALYTICS_ASSIGNMENT_TYPE = 'cru.assignment-type';
 export const ANALYTICS_EDIT_MODE = 'cru.edit-mode';
 export const ANALYTICS_PERMISSION_TYPE = 'cru.permission-type';
-export const ANALYTICS_MINISTRY_MODE = 'cru.ministry-mode';
 
 export const ID_SCHEMA = 'iglu:org.cru/ids/jsonschema/1-0-3';
 export const LOGGED_IN = 'logged in';

--- a/src/containers/AddContactScreen/__tests__/AddContactScreen.tsx
+++ b/src/containers/AddContactScreen/__tests__/AddContactScreen.tsx
@@ -62,7 +62,7 @@ const closeDrawerResults = { type: 'drawer closed' };
 const next = jest.fn();
 
 const initialState = {
-  auth: { person: me, isJean: false },
+  auth: { person: me },
   drawer: { isOpen: false },
 };
 

--- a/src/containers/PeopleScreen/__tests__/PeopleScreen.tsx
+++ b/src/containers/PeopleScreen/__tests__/PeopleScreen.tsx
@@ -97,7 +97,6 @@ const people = [
 ];
 
 const props = {
-  isJean: true,
   hasNoContacts: false,
   items: orgs,
   dispatch: jest.fn(response => Promise.resolve(response)),
@@ -108,7 +107,6 @@ it('renders empty correctly', () => {
   renderWithContext(
     <PeopleScreen
       {...props}
-      isJean={false}
       items={[{ id: 'me person' }]}
       hasNoContacts={true}
     />,
@@ -123,9 +121,7 @@ it('renders empty correctly', () => {
 });
 
 it('renders correctly as Casey', () => {
-  renderWithContext(
-    <PeopleScreen {...props} isJean={false} items={people} />,
-  ).snapshot();
+  renderWithContext(<PeopleScreen {...props} items={people} />).snapshot();
 
   expect(useAnalytics).toHaveBeenCalledWith('people', {
     screenType: ANALYTICS_SCREEN_TYPES.screenWithDrawer,
@@ -141,39 +137,35 @@ it('should open main menu', () => {
 });
 
 describe('handleAddContact', () => {
-  describe('not isJean', () => {
-    describe('press header button', () => {
-      it('should navigate to add person flow', () => {
-        const { getByTestId } = renderWithContext(
-          <PeopleScreen {...props} isJean={false} />,
-        );
+  describe('press header button', () => {
+    it('should navigate to add person flow', () => {
+      const { getByTestId } = renderWithContext(<PeopleScreen {...props} />);
 
-        fireEvent.press(getByTestId('header').props.right);
+      fireEvent.press(getByTestId('header').props.right);
 
-        expect(navigatePush).toHaveBeenCalledWith(
-          ADD_PERSON_THEN_PEOPLE_SCREEN_FLOW,
-          {
-            organization: undefined,
-          },
-        );
-      });
+      expect(navigatePush).toHaveBeenCalledWith(
+        ADD_PERSON_THEN_PEOPLE_SCREEN_FLOW,
+        {
+          organization: undefined,
+        },
+      );
     });
+  });
 
-    describe('press bottom button', () => {
-      it('should navigate to add person flow', () => {
-        const { getByTestId } = renderWithContext(
-          <PeopleScreen {...props} isJean={false} hasNoContacts={true} />,
-        );
+  describe('press bottom button', () => {
+    it('should navigate to add person flow', () => {
+      const { getByTestId } = renderWithContext(
+        <PeopleScreen {...props} hasNoContacts={true} />,
+      );
 
-        fireEvent.press(getByTestId('bottomButton'));
+      fireEvent.press(getByTestId('bottomButton'));
 
-        expect(navigatePush).toHaveBeenCalledWith(
-          ADD_PERSON_THEN_PEOPLE_SCREEN_FLOW,
-          {
-            organization: undefined,
-          },
-        );
-      });
+      expect(navigatePush).toHaveBeenCalledWith(
+        ADD_PERSON_THEN_PEOPLE_SCREEN_FLOW,
+        {
+          organization: undefined,
+        },
+      );
     });
   });
 });

--- a/src/containers/PeopleScreen/index.tsx
+++ b/src/containers/PeopleScreen/index.tsx
@@ -29,7 +29,6 @@ interface PeopleScreenProps {
   dispatch: ThunkDispatch<any, null, never>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   items: any;
-  isJean: boolean;
   hasNoContacts: boolean;
   person: Person;
 }

--- a/src/reducers/__tests__/auth.ts
+++ b/src/reducers/__tests__/auth.ts
@@ -6,7 +6,6 @@ import {
   UPDATE_STAGES,
   UPDATE_TOKEN,
 } from '../../constants';
-import * as common from '../../utils/common';
 
 const token = 'asdfasndfiosdc';
 const personId = '123456';
@@ -84,28 +83,6 @@ it('does not set new token after refreshing anonymous login if user is logged ou
   );
 
   expect(state).toEqual({ ...initialState, token: '' });
-});
-
-it('sets isJean after loading me', () => {
-  const isJeanResponse = 'isJean';
-  // @ts-ignore
-  common.userIsJean = jest.fn().mockReturnValue(isJeanResponse);
-
-  const organizational_permissions = [
-    { id: 1, type: 'organizational_permission' },
-  ];
-  const response = {
-    type: 'person',
-    organizational_permissions,
-    user: {
-      groups_feature: true,
-    },
-  };
-
-  const state = callAuth(REQUESTS.GET_ME.SUCCESS, { response });
-
-  expect(state.isJean).toBe(isJeanResponse);
-  expect(common.userIsJean).toHaveBeenCalledWith(organizational_permissions);
 });
 
 it('sets unread_comments_count', () => {
@@ -209,7 +186,6 @@ it('should reset state on logout', () => {
       token: 'some token',
       refreshToken: 'some refresh token',
       person: { user: { id: '1' } },
-      isJean: true,
       upgradeToken: 'some upgrade token',
     },
     {
@@ -221,7 +197,6 @@ it('should reset state on logout', () => {
     token: undefined,
     refreshToken: '',
     person: { user: {} },
-    isJean: false,
     upgradeToken: null,
   });
 });

--- a/src/reducers/analytics.ts
+++ b/src/reducers/analytics.ts
@@ -9,7 +9,6 @@ import {
   ANALYTICS_GR_MASTER_PERSON_ID,
   ANALYTICS_FACEBOOK_ID,
   ANALYTICS_CONTENT_LANGUAGE,
-  ANALYTICS_MINISTRY_MODE,
   NOT_LOGGED_IN,
   LOGOUT,
   RELOAD_APP,
@@ -33,7 +32,6 @@ export interface AnalyticsState {
   [ANALYTICS_GR_MASTER_PERSON_ID]: TrackStateContext[typeof ANALYTICS_GR_MASTER_PERSON_ID];
   [ANALYTICS_FACEBOOK_ID]: TrackStateContext[typeof ANALYTICS_FACEBOOK_ID];
   [ANALYTICS_CONTENT_LANGUAGE]: TrackStateContext[typeof ANALYTICS_CONTENT_LANGUAGE];
-  [ANALYTICS_MINISTRY_MODE]: TrackStateContext[typeof ANALYTICS_MINISTRY_MODE];
 }
 
 export const initialAnalyticsState = {
@@ -45,7 +43,6 @@ export const initialAnalyticsState = {
   [ANALYTICS_GR_MASTER_PERSON_ID]: '',
   [ANALYTICS_FACEBOOK_ID]: '',
   [ANALYTICS_CONTENT_LANGUAGE]: i18next.language,
-  [ANALYTICS_MINISTRY_MODE]: false,
 };
 
 export interface AnalyticsContextChangedAction {
@@ -97,7 +94,6 @@ function analyticsReducer(
         [ANALYTICS_SSO_GUID]: '',
         [ANALYTICS_GR_MASTER_PERSON_ID]: '',
         [ANALYTICS_FACEBOOK_ID]: '',
-        [ANALYTICS_MINISTRY_MODE]: false,
       };
     default:
       return state;

--- a/src/reducers/auth.ts
+++ b/src/reducers/auth.ts
@@ -6,7 +6,6 @@ import {
   UPDATE_STAGES,
   UPDATE_TOKEN,
 } from '../constants';
-import { userIsJean } from '../utils/common';
 import { REQUESTS } from '../api/routes';
 
 import { Person } from './people';
@@ -20,7 +19,6 @@ export interface AuthState {
   token?: string;
   refreshToken: string;
   person: Person;
-  isJean: boolean;
   upgradeToken: string | null;
 }
 
@@ -28,7 +26,6 @@ const initialAuthState: AuthState = {
   token: undefined,
   refreshToken: '',
   person: { user: {} },
-  isJean: false,
   upgradeToken: null,
 };
 
@@ -102,7 +99,6 @@ function authReducer(state = initialAuthState, action: any) {
           ...person,
           stage: state.person.id === person.id ? state.person.stage : null, // Add the stage if we're getting the same user again
         },
-        isJean: userIsJean(person.organizational_permissions),
       };
     case REQUESTS.GET_UNREAD_COMMENTS_NOTIFICATION.SUCCESS:
       return {

--- a/src/routes/editPerson/__tests__/editPersonFlow.tsx
+++ b/src/routes/editPerson/__tests__/editPersonFlow.tsx
@@ -94,7 +94,7 @@ describe('AddContactScreen next', () => {
       <WrappedAddContactScreen />,
       {
         initialState: {
-          auth: { person: me, isJean: true },
+          auth: { person: me },
           drawer: { isOpen: false },
         },
         navParams: {},
@@ -118,7 +118,7 @@ describe('AddContactScreen next', () => {
       <WrappedAddContactScreen />,
       {
         initialState: {
-          auth: { person: { id: '1' }, isJean: true },
+          auth: { person: { id: '1' } },
           drawer: { isOpen: false },
         },
         navParams: {
@@ -167,7 +167,7 @@ describe('AddContactScreen next', () => {
       <WrappedAddContactScreen />,
       {
         initialState: {
-          auth: { person: { id: '1' }, isJean: true },
+          auth: { person: { id: '1' } },
           drawer: { isOpen: false },
         },
         navParams: {
@@ -214,7 +214,7 @@ describe('AddContactScreen next', () => {
       <WrappedAddContactScreen />,
       {
         initialState: {
-          auth: { person: { id: '1' }, isJean: true },
+          auth: { person: { id: '1' } },
           drawer: { isOpen: false },
         },
         navParams: {
@@ -258,7 +258,7 @@ describe('SelectStageScreen next', () => {
       <WrappedSelectStageScreen next={next} />,
       {
         initialState: {
-          auth: { person: me, isJean: true },
+          auth: { person: me },
           drawer: { isOpen: false },
           people: { people: {} },
           stages: { stages },

--- a/src/utils/__tests__/common.ts
+++ b/src/utils/__tests__/common.ts
@@ -5,7 +5,6 @@ import Config from 'react-native-config';
 
 import {
   buildTrackingObj,
-  userIsJean,
   orgIsPersonalMinistry,
   orgIsUserCreated,
   orgIsCru,
@@ -121,22 +120,6 @@ describe('isOnboarding', () => {
     expect(
       isOnboarding({ currentlyOnboarding: false } as OnboardingState),
     ).toEqual(false);
-  });
-});
-
-describe('userIsJean', () => {
-  const caseyPermissions = [
-    { id: '1', organization: { id: '1', user_created: true } },
-  ];
-  const jeanPermissions = [
-    ...caseyPermissions,
-    { id: '2', organization: { id: '2', user_created: false } },
-  ];
-  it('should return false for Casey', () => {
-    expect(userIsJean(caseyPermissions)).toEqual(false);
-  });
-  it('should return true for Jean', () => {
-    expect(userIsJean(jeanPermissions)).toEqual(true);
   });
 });
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -96,11 +96,6 @@ export const personIsCurrentUser = (personId: string, authState: AuthState) =>
 export const isOnboarding = (onboardingState: OnboardingState) =>
   onboardingState.currentlyOnboarding;
 
-//If the user has permissions in a Cru Community (that is, user_created === false), they are Jean
-export const userIsJean = (
-  orgPermissions: { organization: { user_created: boolean } }[],
-) => orgPermissions.some(p => !p.organization.user_created);
-
 export const orgIsPersonalMinistry = (org?: { id?: string }) =>
   !!org && (!org.id || org.id === 'personal');
 


### PR DESCRIPTION
This is only part of https://jira.cru.org/browse/MHP-3361 but seemed cleaner to do it individually.

It seemed useless to continue sending the `ANALYTICS_MINISTRY_MODE` context if it will always be false so I removed it. Let me know if you see any issues with that. Maybe the analytics team needs to be notified.