### PR TITLE
Run develop branch against production to catch changes that are unsup…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       before_script:
         - echo "TRAVIS_COMMIT=$TRAVIS_COMMIT" >> ./.env.production
         - |
-          if [ "$TRAVIS_BRANCH" == "master" ]; then
+          if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "develop" ]; then
             echo "Setting ENVFILE to .env.production"
             export ENVFILE=.env.production
           else


### PR DESCRIPTION
…ported by prod sooner

We keep merging things into `develop` that are unsupported by production and then run into errors trying to merge `develop` into `master` for a TestFlight build. This is annoying for Spencer as he has to quickly deploy or extract changes (sometimes after hours) in order to unblock a TestFlight build. Making `develop` run against production should encourage us to QA and deploy API tickets before merging client PRs into `develop` and make the process of creating a TestFlight build simpler. It might keep PRs open slightly longer but that should encourage us to communicate and get things QAed and deployed sooner.

If you make a PR and see the **Travis CI - Branch** check succeed and the **Travis CI - Pull Request** check fail, this is probably why.

Let me know if you see any issues with this :) 