### PR TITLE
MHP-3597 - Only allow "edit/delete" options for certain feed item types

### DIFF
--- a/src/components/CommunityFeedItem/index.tsx
+++ b/src/components/CommunityFeedItem/index.tsx
@@ -25,7 +25,7 @@ import {
   GetCommunityFeedVariables,
 } from '../../containers/CommunityFeed/__generated__/GetCommunityFeed';
 import { GET_COMMUNITY_FEED } from '../../containers/CommunityFeed/queries';
-import { getFeedItemType } from '../../utils/common';
+import { getFeedItemType, canModifyFeedItemSubject } from '../../utils/common';
 
 import styles from './styles';
 import { DeletePost, DeletePostVariables } from './__generated__/DeletePost';
@@ -199,9 +199,10 @@ export const CommunityFeedItem = ({
       },
     ]);
 
+  const canModify = canModifyFeedItemSubject(subject);
   const menuActions =
     !isGlobal && isPost(subject)
-      ? isMe
+      ? isMe && canModify
         ? [
             {
               text: t('edit.buttonText'),

--- a/src/containers/Communities/Community/CommunityFeedTab/FeedItemDetailScreen/FeedItemDetailScreen.tsx
+++ b/src/containers/Communities/Community/CommunityFeedTab/FeedItemDetailScreen/FeedItemDetailScreen.tsx
@@ -32,7 +32,11 @@ import {
   useDeleteFeedItem,
   useEditFeedItem,
 } from '../../../../../components/CommunityFeedItem';
-import { isOwner, isAdminOrOwner } from '../../../../../utils/common';
+import {
+  isOwner,
+  isAdminOrOwner,
+  canModifyFeedItemSubject,
+} from '../../../../../utils/common';
 import theme from '../../../../../theme';
 
 import FeedCommentBox from './FeedCommentBox';
@@ -167,25 +171,28 @@ const FeedItemDetailScreen = () => {
     </SafeAreaView>
   );
 
-  const menuActions = [
-    ...(isMe
-      ? [
-          {
-            text: t('communityFeedItems:edit.buttonText'),
-            onPress: editFeedItem,
-          },
-        ]
-      : []),
-    ...(isMe || isAdminOrOwner(communityPermission)
-      ? [
-          {
-            text: t('communityFeedItems:delete.buttonText'),
-            onPress: () => deleteFeedItem(() => dispatch(navigateBack())),
-            destructive: true,
-          },
-        ]
-      : []),
-  ];
+  const canModify = canModifyFeedItemSubject(data?.feedItem.subject);
+  const menuActions = !canModify
+    ? []
+    : [
+        ...(isMe
+          ? [
+              {
+                text: t('communityFeedItems:edit.buttonText'),
+                onPress: editFeedItem,
+              },
+            ]
+          : []),
+        ...(isMe || isAdminOrOwner(communityPermission)
+          ? [
+              {
+                text: t('communityFeedItems:delete.buttonText'),
+                onPress: () => deleteFeedItem(() => dispatch(navigateBack())),
+                destructive: true,
+              },
+            ]
+          : []),
+      ];
 
   const renderCommentsList = () =>
     data ? (

--- a/src/utils/__tests__/common.ts
+++ b/src/utils/__tests__/common.ts
@@ -30,6 +30,7 @@ import {
   mapPostTypeToFeedType,
   mapFeedTypeToPostType,
   getFeedItemType,
+  canModifyFeedItemSubject,
 } from '../common';
 import {
   MAIN_MENU_DRAWER,
@@ -774,5 +775,69 @@ describe('getFeedItemType', () => {
     expect(
       getFeedItemType({ ...post, postType: PostTypeEnum.announcement }),
     ).toEqual(FeedItemSubjectTypeEnum.ANNOUNCEMENT);
+  });
+});
+
+describe('canModifyFeedItemSubject', () => {
+  const post: CommunityFeedItem_subject_Post = {
+    __typename: 'Post',
+    id: '1',
+    content: 'asdf',
+    mediaContentType: '',
+    mediaExpiringUrl: '',
+    postType: PostTypeEnum.story,
+    stepStatus: PostStepStatusEnum.INCOMPLETE,
+  };
+  function check(postType: PostTypeEnum) {
+    return canModifyFeedItemSubject({ ...post, postType });
+  }
+
+  it('returns STEP', () => {
+    const step: CommunityFeedItem_subject_Step = {
+      __typename: 'Step',
+      id: '1',
+      receiverStageAtCompletion: null,
+    };
+
+    expect(canModifyFeedItemSubject(step)).toEqual(false);
+  });
+
+  it('returns ACCEPTED_COMMUNITY_CHALLENGE', () => {
+    const challenge: CommunityFeedItem_subject_AcceptedCommunityChallenge = {
+      __typename: 'AcceptedCommunityChallenge',
+      id: '1',
+      completedAt: 'some time',
+      communityChallenge: {
+        __typename: 'CommunityChallenge',
+        id: '1',
+        title: 'asdf',
+      },
+    };
+
+    expect(canModifyFeedItemSubject(challenge)).toEqual(false);
+  });
+
+  it('returns STORY', () => {
+    expect(check(PostTypeEnum.story)).toEqual(true);
+  });
+
+  it('returns PRAYER_REQUEST', () => {
+    expect(check(PostTypeEnum.prayer_request)).toEqual(true);
+  });
+
+  it('returns QUESTION', () => {
+    expect(check(PostTypeEnum.question)).toEqual(true);
+  });
+
+  it('returns HELP_REQUEST', () => {
+    expect(check(PostTypeEnum.help_request)).toEqual(true);
+  });
+
+  it('returns THOUGHT', () => {
+    expect(check(PostTypeEnum.thought)).toEqual(true);
+  });
+
+  it('returns ANNOUNCEMENT', () => {
+    expect(check(PostTypeEnum.announcement)).toEqual(true);
   });
 });

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -412,3 +412,17 @@ export const getFeedItemType = (subject: CommunityFeedItem_subject) => {
       return FeedItemSubjectTypeEnum.STORY;
   }
 };
+export const canModifyFeedItemSubject = (
+  subject?: CommunityFeedItem_subject,
+) => {
+  const itemType = subject && getFeedItemType(subject);
+  return [
+    FeedItemSubjectTypeEnum.ANNOUNCEMENT,
+    FeedItemSubjectTypeEnum.HELP_REQUEST,
+    FeedItemSubjectTypeEnum.PRAYER_REQUEST,
+    FeedItemSubjectTypeEnum.QUESTION,
+    FeedItemSubjectTypeEnum.STORY,
+    FeedItemSubjectTypeEnum.THOUGHT,
+    FeedItemSubjectTypeEnum.THOUGHT,
+  ].includes(itemType as FeedItemSubjectTypeEnum);
+};


### PR DESCRIPTION
Dont allow steps/challenges/other post types to be editable/deleted from the popup menu.