### PR TITLE
MHP-3573: Fix markdown styles after migration to react-native-markdow…

### DIFF
--- a/src/components/ChallengeDetailHeader/__tests__/__snapshots__/ChallengeDetailHeader.tsx.snap
+++ b/src/components/ChallengeDetailHeader/__tests__/__snapshots__/ChallengeDetailHeader.tsx.snap
@@ -309,13 +309,13 @@ exports[`render for active challenge 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -640,13 +640,13 @@ exports[`render for past challenge 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -1267,13 +1267,13 @@ exports[`renders with details 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
                       },
+                      Object {},
                     ]
                   }
                 >

--- a/src/components/CommunityFeedItem/__tests__/__snapshots__/CommunityFeedItem.tsx.snap
+++ b/src/components/CommunityFeedItem/__tests__/__snapshots__/CommunityFeedItem.tsx.snap
@@ -684,13 +684,13 @@ exports[`Community renders post correctly with add to steps button 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -1238,13 +1238,13 @@ exports[`Community renders post correctly without add to steps button  1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -1728,13 +1728,13 @@ exports[`Community renders post correctly without image 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -2250,13 +2250,13 @@ exports[`Community renders post created by me correctly without add to steps but
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -3190,13 +3190,13 @@ exports[`Community renders with clear notification button correctly 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -4079,13 +4079,13 @@ exports[`global community renders post item correctly 1`] = `
             <Text
               style={
                 Array [
-                  Object {},
                   Object {
                     "color": "#505256",
                     "fontFamily": "SourceSansPro-Regular",
                     "fontSize": 14,
                     "lineHeight": 18,
                   },
+                  Object {},
                 ]
               }
             >
@@ -4958,13 +4958,13 @@ exports[`renders with name pressable correctly 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >

--- a/src/components/CommunityFeedItemContent/__tests__/__snapshots__/CommunityFeedItemContent.tsx.snap
+++ b/src/components/CommunityFeedItemContent/__tests__/__snapshots__/CommunityFeedItemContent.tsx.snap
@@ -1864,13 +1864,13 @@ Array [
           <Text
             style={
               Array [
-                Object {},
                 Object {
                   "color": "#505256",
                   "fontFamily": "SourceSansPro-Regular",
                   "fontSize": 14,
                   "lineHeight": 18,
                 },
+                Object {},
               ]
             }
           >
@@ -2327,13 +2327,13 @@ Array [
           <Text
             style={
               Array [
-                Object {},
                 Object {
                   "color": "#505256",
                   "fontFamily": "SourceSansPro-Regular",
                   "fontSize": 14,
                   "lineHeight": 18,
                 },
+                Object {},
               ]
             }
           >
@@ -2854,13 +2854,13 @@ Array [
           <Text
             style={
               Array [
-                Object {},
                 Object {
                   "color": "#505256",
                   "fontFamily": "SourceSansPro-Regular",
                   "fontSize": 14,
                   "lineHeight": 18,
                 },
+                Object {},
               ]
             }
           >
@@ -3317,13 +3317,13 @@ Array [
           <Text
             style={
               Array [
-                Object {},
                 Object {
                   "color": "#505256",
                   "fontFamily": "SourceSansPro-Regular",
                   "fontSize": 14,
                   "lineHeight": 18,
                 },
+                Object {},
               ]
             }
           >
@@ -7533,13 +7533,13 @@ Array [
           <Text
             style={
               Array [
-                Object {},
                 Object {
                   "color": "#505256",
                   "fontFamily": "SourceSansPro-Regular",
                   "fontSize": 14,
                   "lineHeight": 18,
                 },
+                Object {},
               ]
             }
           >
@@ -7967,13 +7967,13 @@ Array [
           <Text
             style={
               Array [
-                Object {},
                 Object {
                   "color": "#505256",
                   "fontFamily": "SourceSansPro-Regular",
                   "fontSize": 14,
                   "lineHeight": 18,
                 },
+                Object {},
               ]
             }
           >
@@ -8431,13 +8431,13 @@ Array [
           <Text
             style={
               Array [
-                Object {},
                 Object {
                   "color": "#505256",
                   "fontFamily": "SourceSansPro-Regular",
                   "fontSize": 14,
                   "lineHeight": 18,
                 },
+                Object {},
               ]
             }
           >
@@ -9388,13 +9388,13 @@ Array [
           <Text
             style={
               Array [
-                Object {},
                 Object {
                   "color": "#505256",
                   "fontFamily": "SourceSansPro-Regular",
                   "fontSize": 14,
                   "lineHeight": 18,
                 },
+                Object {},
               ]
             }
           >
@@ -10348,13 +10348,13 @@ Array [
           <Text
             style={
               Array [
-                Object {},
                 Object {
                   "color": "#505256",
                   "fontFamily": "SourceSansPro-Regular",
                   "fontSize": 14,
                   "lineHeight": 18,
                 },
+                Object {},
               ]
             }
           >

--- a/src/components/CommunityFeedItemContent/styles.ts
+++ b/src/components/CommunityFeedItemContent/styles.ts
@@ -126,8 +126,8 @@ export default StyleSheet.create({
 
 export const markdown = StyleSheet.create({
   ...markdownStyles,
-  text: {
-    ...markdownStyles.text,
+  body: {
+    ...markdownStyles.body,
     fontSize: 14,
     lineHeight: 18,
   },

--- a/src/components/StepDetailScreen/__tests__/__snapshots__/StepDetailScreen.tsx.snap
+++ b/src/components/StepDetailScreen/__tests__/__snapshots__/StepDetailScreen.tsx.snap
@@ -356,7 +356,11 @@ exports[`Post is not null renders correctly with post 1`] = `
           }
         >
           <View
-            style={Object {}}
+            style={
+              Object {
+                "paddingBottom": 20,
+              }
+            }
           >
             <View
               style={
@@ -378,14 +382,13 @@ exports[`Post is not null renders correctly with post 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
-                        "paddingBottom": 20,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -779,7 +782,11 @@ exports[`Post is not null renders correctly with post with image 1`] = `
           }
         >
           <View
-            style={Object {}}
+            style={
+              Object {
+                "paddingBottom": 20,
+              }
+            }
           >
             <View
               style={
@@ -801,14 +808,13 @@ exports[`Post is not null renders correctly with post with image 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
-                        "paddingBottom": 20,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -1202,7 +1208,11 @@ exports[`Post is not null renders post without image 1`] = `
           }
         >
           <View
-            style={Object {}}
+            style={
+              Object {
+                "paddingBottom": 20,
+              }
+            }
           >
             <View
               style={
@@ -1224,14 +1234,13 @@ exports[`Post is not null renders post without image 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
-                        "paddingBottom": 20,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -1584,7 +1593,11 @@ exports[`Post is not null renders with an input 1`] = `
           }
         >
           <View
-            style={Object {}}
+            style={
+              Object {
+                "paddingBottom": 20,
+              }
+            }
           >
             <View
               style={
@@ -1606,14 +1619,13 @@ exports[`Post is not null renders with an input 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
-                        "paddingBottom": 20,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -2107,13 +2119,13 @@ exports[`markdown is not null renders correctly 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >
@@ -2371,13 +2383,13 @@ exports[`markdown is not null renders correctly on android 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >
@@ -2635,13 +2647,13 @@ exports[`markdown is not null renders correctly on android with bottom button pr
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >
@@ -2981,13 +2993,13 @@ exports[`markdown is not null renders correctly with bottom button props 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >
@@ -3835,13 +3847,13 @@ exports[`markdown with <<name>> to change renders correctly 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >

--- a/src/components/StepDetailScreen/index.tsx
+++ b/src/components/StepDetailScreen/index.tsx
@@ -101,8 +101,8 @@ const StepDetailScreen = ({
               <Markdown
                 style={{
                   ...markdownStyles,
-                  text: {
-                    ...markdownStyles.text,
+                  body: {
+                    ...markdownStyles.body,
                     fontSize: 16,
                     color: theme.grey,
                     paddingBottom: 20,

--- a/src/containers/AcceptedStepDetailScreen/__tests__/__snapshots__/AcceptedStepDetailScreen.tsx.snap
+++ b/src/containers/AcceptedStepDetailScreen/__tests__/__snapshots__/AcceptedStepDetailScreen.tsx.snap
@@ -559,7 +559,11 @@ exports[`should render correctly post details 1`] = `
           }
         >
           <View
-            style={Object {}}
+            style={
+              Object {
+                "paddingBottom": 20,
+              }
+            }
           >
             <View
               style={
@@ -581,14 +585,13 @@ exports[`should render correctly post details 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
-                        "paddingBottom": 20,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -2371,13 +2374,13 @@ exports[`with description, with reminder should render correctly 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >
@@ -2848,13 +2851,13 @@ exports[`with description, without reminder should render correctly 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >

--- a/src/containers/AddPostToStepsScreen/__tests__/__snapshots__/AddPostToStepsScreen.tsx.snap
+++ b/src/containers/AddPostToStepsScreen/__tests__/__snapshots__/AddPostToStepsScreen.tsx.snap
@@ -369,7 +369,11 @@ exports[`should render correctly | Care Step 1`] = `
           }
         >
           <View
-            style={Object {}}
+            style={
+              Object {
+                "paddingBottom": 20,
+              }
+            }
           >
             <View
               style={
@@ -391,14 +395,13 @@ exports[`should render correctly | Care Step 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
-                        "paddingBottom": 20,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -866,7 +869,11 @@ exports[`should render correctly | Pray Step 1`] = `
           }
         >
           <View
-            style={Object {}}
+            style={
+              Object {
+                "paddingBottom": 20,
+              }
+            }
           >
             <View
               style={
@@ -888,14 +895,13 @@ exports[`should render correctly | Pray Step 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
-                        "paddingBottom": 20,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -1364,7 +1370,11 @@ exports[`should render correctly | Share Step 1`] = `
           }
         >
           <View
-            style={Object {}}
+            style={
+              Object {
+                "paddingBottom": 20,
+              }
+            }
           >
             <View
               style={
@@ -1386,14 +1396,13 @@ exports[`should render correctly | Share Step 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
-                        "paddingBottom": 20,
                       },
+                      Object {},
                     ]
                   }
                 >

--- a/src/containers/ChallengeDetailScreen/__tests__/__snapshots__/ChallengeDetailScreen.tsx.snap
+++ b/src/containers/ChallengeDetailScreen/__tests__/__snapshots__/ChallengeDetailScreen.tsx.snap
@@ -512,13 +512,13 @@ exports[`should call navigateBack from press 1`] = `
                   <Text
                     style={
                       Array [
-                        Object {},
                         Object {
                           "color": "#505256",
                           "fontFamily": "SourceSansPro-Regular",
                           "fontSize": 16,
                           "lineHeight": 24,
                         },
+                        Object {},
                       ]
                     }
                   >
@@ -1169,13 +1169,13 @@ exports[`should render completed challenge correctly 1`] = `
                   <Text
                     style={
                       Array [
-                        Object {},
                         Object {
                           "color": "#505256",
                           "fontFamily": "SourceSansPro-Regular",
                           "fontSize": 16,
                           "lineHeight": 24,
                         },
+                        Object {},
                       ]
                     }
                   >
@@ -1719,13 +1719,13 @@ exports[`should render joined challenge correctly 1`] = `
                   <Text
                     style={
                       Array [
-                        Object {},
                         Object {
                           "color": "#505256",
                           "fontFamily": "SourceSansPro-Regular",
                           "fontSize": 16,
                           "lineHeight": 24,
                         },
+                        Object {},
                       ]
                     }
                   >
@@ -2376,13 +2376,13 @@ exports[`should render unjoined challenge correctly 1`] = `
                   <Text
                     style={
                       Array [
-                        Object {},
                         Object {
                           "color": "#505256",
                           "fontFamily": "SourceSansPro-Regular",
                           "fontSize": 16,
                           "lineHeight": 24,
                         },
+                        Object {},
                       ]
                     }
                   >

--- a/src/containers/Communities/Community/CommunityFeedTab/FeedItemDetailScreen/__tests__/__snapshots__/FeedItemDetailScreen.tsx.snap
+++ b/src/containers/Communities/Community/CommunityFeedTab/FeedItemDetailScreen/__tests__/__snapshots__/FeedItemDetailScreen.tsx.snap
@@ -495,13 +495,13 @@ exports[`edit/delete post delete for admin and not my post 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -1397,13 +1397,13 @@ exports[`edit/delete post edit and delete for my post 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -2266,13 +2266,13 @@ exports[`edit/delete post no options for not my post 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -3420,13 +3420,13 @@ exports[`renders correctly 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -4287,13 +4287,13 @@ exports[`renders correctly with communityId passed in 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 14,
                         "lineHeight": 18,
                       },
+                      Object {},
                     ]
                   }
                 >

--- a/src/containers/CompletedStepDetailScreen/__tests__/__snapshots__/CompletedStepDetailScreen.tsx.snap
+++ b/src/containers/CompletedStepDetailScreen/__tests__/__snapshots__/CompletedStepDetailScreen.tsx.snap
@@ -299,13 +299,13 @@ exports[`post renders with post 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >
@@ -451,7 +451,11 @@ exports[`post renders with post 1`] = `
           }
         >
           <View
-            style={Object {}}
+            style={
+              Object {
+                "paddingBottom": 20,
+              }
+            }
           >
             <View
               style={
@@ -473,14 +477,13 @@ exports[`post renders with post 1`] = `
                 <Text
                   style={
                     Array [
-                      Object {},
                       Object {
                         "color": "#505256",
                         "fontFamily": "SourceSansPro-Regular",
                         "fontSize": 16,
                         "lineHeight": 24,
-                        "paddingBottom": 20,
                       },
+                      Object {},
                     ]
                   }
                 >
@@ -817,13 +820,13 @@ exports[`post renders without post 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >
@@ -1404,13 +1407,13 @@ exports[`with challenge suggestion renders correctly 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >
@@ -1724,13 +1727,13 @@ exports[`without challenge suggestion renders correctly 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >

--- a/src/containers/SuggestedStepDetailScreen/__tests__/__snapshots__/SuggestedStepDetailScreen.tsx.snap
+++ b/src/containers/SuggestedStepDetailScreen/__tests__/__snapshots__/SuggestedStepDetailScreen.tsx.snap
@@ -233,13 +233,13 @@ exports[`renders correctly 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >
@@ -569,13 +569,13 @@ exports[`renders correctly for me 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >
@@ -905,13 +905,13 @@ exports[`renders correctly in onboarding 1`] = `
               <Text
                 style={
                   Array [
-                    Object {},
                     Object {
                       "color": "#505256",
                       "fontFamily": "SourceSansPro-Regular",
                       "fontSize": 16,
                       "lineHeight": 24,
                     },
+                    Object {},
                   ]
                 }
               >

--- a/src/markdownStyles.ts
+++ b/src/markdownStyles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import theme from './theme';
 
@@ -9,7 +9,6 @@ const textStyle = {
   lineHeight: 24,
 };
 const heading1Style = {
-  ...textStyle,
   fontFamily: 'SourceSansPro-Light',
   fontSize: 32,
   lineHeight: 38,
@@ -28,32 +27,28 @@ const heading3Style = {
   marginVertical: 16,
 };
 const strongStyle = {
-  ...textStyle,
   fontFamily: 'SourceSansPro-Bold',
 };
 const emphasisStyle = {
-  ...textStyle,
   fontFamily: 'SourceSansPro-Italic',
 };
 const paragraph = {
   marginVertical: 10,
 };
-const listItemOrderedIconStyle = {
-  ...textStyle,
-  marginRight: 16,
-  alignSelf: 'center',
-  lineHeight: 36,
-};
 const listItemUnorderedIconStyle = {
-  ...listItemOrderedIconStyle,
-  fontSize: 30,
+  ...Platform.select({
+    ios: {
+      // Make bullet bigger
+      fontSize: 30,
+      // Make bullet aligned vertically with first line instead of shifted above it
+      lineHeight: 42,
+    },
+  }),
 };
 const linkStyle = {
-  ...textStyle,
   lineHeight: 22,
   color: theme.secondaryColor,
   textDecorationColor: theme.secondaryColor,
-  textDecorationLine: 'underline',
 };
 const blockQuoteStyle = {
   left: -32,
@@ -77,18 +72,14 @@ const imageStyle = {
 };
 
 export default StyleSheet.create({
-  text: textStyle,
+  body: textStyle,
   heading1: heading1Style,
   heading2: heading2Style,
   heading3: heading3Style,
   strong: strongStyle,
   em: emphasisStyle,
   paragraph: paragraph,
-  // @ts-ignore
-  listUnorderedItemIcon: listItemUnorderedIconStyle,
-  // @ts-ignore
-  listOrderedItemIcon: listItemOrderedIconStyle,
-  // @ts-ignore
+  bullet_list_icon: listItemUnorderedIconStyle,
   link: linkStyle,
   blockquote: blockQuoteStyle,
   hr: horizontalLineStyle,


### PR DESCRIPTION
…n-display

Main changes were moving `text` styles to `body` so they apply everywhere https://github.com/iamacup/react-native-markdown-display#how-to-style-stuff and fixing the bullet points.

Steve reported this here https://jira.cru.org/browse/MHP-3573?focusedCommentId=90741&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-90741