### PR TITLE
Revert "MHP-3391: Refresh auth token if needed on GraphQL requests"

### DIFF
--- a/src/actions/__tests__/api.ts
+++ b/src/actions/__tests__/api.ts
@@ -4,7 +4,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import callApi from '../api';
-import { ApiRouteConfigEntry, REQUESTS } from '../../api/routes';
+import { REQUESTS } from '../../api/routes';
 import API_CALLS from '../../api';
 import {
   EXPIRED_ACCESS_TOKEN,
@@ -13,7 +13,6 @@ import {
   UPDATE_TOKEN,
 } from '../../constants';
 import { logout, handleInvalidAccessToken } from '../auth/auth';
-import { AuthState } from '../../reducers/auth';
 
 jest.mock('../../api');
 jest.mock('../auth/anonymous');
@@ -24,10 +23,10 @@ jest.mock('../auth/key');
 const token = 'alsnjfjwqfpuqfeownposfnjnsaobjfaslkklnsfd';
 const refreshToken = 'refresh';
 const mockStore = configureStore([thunk]);
+let store;
 const mockAuthState = {
   token,
 };
-const mockActionResult = { type: 'mockActionResult' };
 
 const accessTokenQuery = { access_token: token };
 const refreshTokenData = `grant_type=refresh_token&refresh_token=${refreshToken}`;
@@ -35,117 +34,117 @@ const refreshTokenData = `grant_type=refresh_token&refresh_token=${refreshToken}
 const getMeRequest = REQUESTS.GET_ME;
 const refreshRequest = REQUESTS.KEY_REFRESH_TOKEN;
 
-const expiredTokenError = {
-  apiError: { errors: [{ detail: EXPIRED_ACCESS_TOKEN }] },
-};
-const invalidTokenError = {
-  apiError: { errors: [{ detail: INVALID_ACCESS_TOKEN }] },
-};
-const invalidGrantError = { apiError: { error: INVALID_GRANT } };
+const expiredTokenError = { errors: [{ detail: EXPIRED_ACCESS_TOKEN }] };
+const invalidTokenError = { errors: [{ detail: INVALID_ACCESS_TOKEN }] };
+const invalidGrantError = { error: INVALID_GRANT };
 
 // @ts-ignore
 global.APILOG = jest.fn();
 
-async function testCallApiWithError({
-  state = {},
+async function test(
+  // @ts-ignore
+  state,
+  // @ts-ignore
   request,
+  // @ts-ignore
   error,
-  action,
-  actionParams = [],
-  actionShouldNotBeCalled = false,
-  query = {},
-  data = {},
-  shouldReject = false,
-}: {
-  state?: Partial<AuthState>;
-  request: ApiRouteConfigEntry;
-  error: { apiError: { errors: { detail: string }[] } | { error: string } };
-  action: () => void;
-  actionParams?: boolean[];
-  actionShouldNotBeCalled?: boolean;
-  query?: { access_token?: string };
-  data?: Record<string, never> | string;
-  shouldReject?: boolean;
-}) {
-  const store = mockStore({ auth: { ...mockAuthState, ...state } });
-  (API_CALLS[request.name] as jest.Mock).mockReturnValue(Promise.reject(error));
-  (action as jest.Mock).mockReturnValue(mockActionResult);
+  // @ts-ignore
+  method,
+  // @ts-ignore
+  methodParams,
+  // @ts-ignore
+  apiResult,
+  // @ts-ignore
+  query,
+  // @ts-ignore
+  data,
+) {
+  store = mockStore({ auth: { ...mockAuthState, ...state } });
+  // @ts-ignore
+  API_CALLS[request.name].mockReturnValue(Promise.reject({ apiError: error }));
+  method.mockReturnValue(apiResult);
 
-  if (!shouldReject) {
+  try {
     // @ts-ignore
     await store.dispatch(callApi(request, query, data));
-  } else {
-    // @ts-ignore
-    await expect(store.dispatch(callApi(request, query, data))).rejects.toEqual(
-      error,
-    );
-  }
+  } catch (e) {
+    expect(API_CALLS[request.name]).toHaveBeenCalledWith(query, data);
+    expect(method).toHaveBeenCalledWith(...methodParams);
 
-  expect(API_CALLS[request.name]).toHaveBeenCalledWith(query, data);
-  if (!actionShouldNotBeCalled) {
-    expect(action).toHaveBeenCalledWith(...actionParams);
-  } else {
-    expect(action).not.toHaveBeenCalledWith(...actionParams);
+    expect(store.getActions()).toEqual([
+      {
+        data,
+        query,
+        type: request.FETCH,
+      },
+      apiResult,
+    ]);
   }
-
-  expect(store.getActions()).toEqual([
-    {
-      data,
-      query,
-      type: request.FETCH,
-    },
-    ...(actionShouldNotBeCalled ? [] : [mockActionResult]),
-  ]);
 }
 
-it('should handle expired token', async () => {
-  await testCallApiWithError({
-    state: { refreshToken: 'refresh' },
-    request: getMeRequest,
-    error: expiredTokenError,
-    action: handleInvalidAccessToken,
-    query: accessTokenQuery,
-  });
-  expect.hasAssertions();
+it('should handle expired token', () => {
+  return test(
+    { refreshToken: 'refresh' },
+    getMeRequest,
+    expiredTokenError,
+    handleInvalidAccessToken,
+    [],
+    { type: 'expired token' },
+    accessTokenQuery,
+    {},
+  );
 });
 
-it('should handle invalid token', async () => {
-  await testCallApiWithError({
-    state: { refreshToken: 'refresh' },
-    request: getMeRequest,
-    error: invalidTokenError,
-    action: handleInvalidAccessToken,
-    query: accessTokenQuery,
-  });
-  expect.hasAssertions();
+it('should handle invalid token', () => {
+  return test(
+    { refreshToken: 'refresh' },
+    getMeRequest,
+    invalidTokenError,
+    handleInvalidAccessToken,
+    [],
+    { type: 'invalid token' },
+    accessTokenQuery,
+    {},
+  );
 });
 
-it('should logout if KEY_REFRESH_TOKEN fails with invalid_grant', async () => {
-  await testCallApiWithError({
-    state: { refreshToken: 'refresh' },
-    request: refreshRequest,
-    error: invalidGrantError,
-    action: logout,
-    actionParams: [true],
-    data: refreshTokenData,
-  });
-  expect.hasAssertions();
+it('should logout if KEY_REFRESH_TOKEN fails with invalid_grant', () => {
+  return test(
+    { refreshToken: 'refresh' },
+    refreshRequest,
+    invalidGrantError,
+    logout,
+    [true],
+    { type: 'logged out' },
+    {},
+    refreshTokenData,
+  );
 });
 
 it("should not logout if invalid_grant is returned and request wasn't KEY_REFRESH_TOKEN", async () => {
-  await testCallApiWithError({
-    request: getMeRequest,
-    error: invalidGrantError,
-    action: logout,
-    actionShouldNotBeCalled: true,
-    query: accessTokenQuery,
-    shouldReject: true,
+  store = mockStore({ auth: { ...mockAuthState } });
+
+  // @ts-ignore
+  API_CALLS[getMeRequest.name].mockReturnValue(
+    Promise.reject({ apiError: invalidGrantError }),
+  );
+
+  // @ts-ignore
+  await expect(store.dispatch(callApi(getMeRequest, {}, {}))).rejects.toEqual({
+    apiError: {
+      error: 'invalid_grant',
+    },
   });
-  expect.hasAssertions();
+
+  expect(API_CALLS[getMeRequest.name]).toHaveBeenCalledWith(
+    accessTokenQuery,
+    {},
+  );
+  expect(logout).not.toHaveBeenCalled();
 });
 
 it('should update token if present in response', async () => {
-  const store = mockStore({ auth: { ...mockAuthState } });
+  store = mockStore({ auth: { ...mockAuthState } });
   const newToken =
     'pfiqwfioqwioefiqowfejiqwfipoioqwefpiowqniopnifiooiwfemiopqwoimefimwqefponioqwfenoiwefinonoiwqefnoip';
 

--- a/src/actions/api.ts
+++ b/src/actions/api.ts
@@ -26,9 +26,9 @@ export default function callApi(
   query: { [key: string]: any } = {},
   data: { [key: string]: any } = {},
 ): ThunkAction<
-  any, // TODO: change to void after https://github.com/CruGlobal/missionhub-react-native/pull/1852 is merged
-  any, // TODO: change to RootState after https://github.com/CruGlobal/missionhub-react-native/pull/1852 is merged
-  null, // TODO: change to never after https://github.com/CruGlobal/missionhub-react-native/pull/1852 is merged
+  any,
+  any,
+  null,
   | {
       query: any;
       data: any;
@@ -97,18 +97,25 @@ export default function callApi(
       APILOG('REQUEST ERROR', action.name, err);
       const { apiError } = err;
 
-      const errorDetail = apiError?.errors?.[0]?.detail;
-      if (
-        errorDetail === EXPIRED_ACCESS_TOKEN ||
-        errorDetail === INVALID_ACCESS_TOKEN
-      ) {
-        return dispatch(handleInvalidAccessToken());
-      } else if (
-        apiError?.error === INVALID_GRANT &&
-        action.name === REQUESTS.KEY_REFRESH_TOKEN.name
-      ) {
-        dispatch(logout(true));
-        return;
+      if (apiError) {
+        if (
+          apiError.errors &&
+          apiError.errors[0] &&
+          apiError.errors[0].detail
+        ) {
+          const errorDetail = apiError.errors[0].detail;
+          if (
+            errorDetail === EXPIRED_ACCESS_TOKEN ||
+            errorDetail === INVALID_ACCESS_TOKEN
+          ) {
+            dispatch(handleInvalidAccessToken());
+          }
+        } else if (
+          apiError.error === INVALID_GRANT &&
+          action.name === REQUESTS.KEY_REFRESH_TOKEN.name
+        ) {
+          dispatch(logout(true));
+        }
       }
       throw err;
     };

--- a/src/actions/auth/anonymous.ts
+++ b/src/actions/auth/anonymous.ts
@@ -1,24 +1,20 @@
-import { ThunkDispatch } from 'redux-thunk';
-import { AnyAction } from 'redux';
-
 import callApi from '../api';
 import { REQUESTS } from '../../api/routes';
-import { RootState } from '../../reducers';
 
 import { authSuccess } from './userData';
 
-export function codeLogin(code: string) {
-  return async (dispatch: ThunkDispatch<RootState, never, AnyAction>) => {
+// @ts-ignore
+export function codeLogin(code) {
+  // @ts-ignore
+  return async dispatch => {
     await dispatch(callApi(REQUESTS.CREATE_MY_PERSON, {}, { code }));
     dispatch(authSuccess());
   };
 }
 
 export function refreshAnonymousLogin() {
-  return (
-    dispatch: ThunkDispatch<RootState, never, AnyAction>,
-    getState: () => RootState,
-  ) => {
+  // @ts-ignore
+  return (dispatch, getState) => {
     const { upgradeToken } = getState().auth;
 
     return dispatch(

--- a/src/actions/auth/auth.ts
+++ b/src/actions/auth/auth.ts
@@ -1,8 +1,6 @@
 import PushNotification from 'react-native-push-notification';
 // @ts-ignore
 import { AccessToken } from 'react-native-fbsdk';
-import { ThunkDispatch } from 'redux-thunk';
-import { AnyAction } from 'redux';
 
 import { CLEAR_UPGRADE_TOKEN, LOGOUT } from '../../constants';
 import { LANDING_SCREEN } from '../../containers/LandingScreen';
@@ -12,14 +10,14 @@ import { deletePushToken } from '../notifications';
 import { SIGN_IN_FLOW } from '../../routes/constants';
 import { getFeatureFlags } from '../misc';
 import { apolloClient } from '../../apolloClient';
-import { RootState } from '../../reducers';
 
 import { refreshAccessToken } from './key';
 import { refreshAnonymousLogin } from './anonymous';
 import { refreshMissionHubFacebookAccess } from './facebook';
 
 export function logout(forcedLogout = false) {
-  return async (dispatch: ThunkDispatch<RootState, never, AnyAction>) => {
+  // @ts-ignore
+  return async dispatch => {
     try {
       await dispatch(deletePushToken());
     } finally {
@@ -42,7 +40,8 @@ export const retryIfInvalidatedClientToken = (
   firstAction,
   // @ts-ignore
   secondAction,
-) => async (dispatch: ThunkDispatch<RootState, never, AnyAction>) => {
+  // @ts-ignore
+) => async dispatch => {
   // Historically we haven't cleared the client_token from redux after use,
   // so if the API throws a client_token invalidated error we retry this request
   // again without the client_token
@@ -63,10 +62,8 @@ export const retryIfInvalidatedClientToken = (
 };
 
 export const handleInvalidAccessToken = () => {
-  return async (
-    dispatch: ThunkDispatch<RootState, never, AnyAction>,
-    getState: () => RootState,
-  ) => {
+  // @ts-ignore
+  return async (dispatch, getState) => {
     const { auth } = getState();
 
     if (auth.refreshToken) {

--- a/src/actions/auth/facebook.ts
+++ b/src/actions/auth/facebook.ts
@@ -1,7 +1,5 @@
 // @ts-ignore
 import { LoginManager, AccessToken } from 'react-native-fbsdk';
-import { ThunkDispatch } from 'redux-thunk';
-import { AnyAction } from 'redux';
 
 import {
   FACEBOOK_CANCELED_ERROR,
@@ -10,7 +8,6 @@ import {
 import callApi from '../api';
 import { REQUESTS } from '../../api/routes';
 import { updateAnalyticsContext } from '../analytics';
-import { RootState } from '../../reducers';
 
 import { retryIfInvalidatedClientToken } from './auth';
 import { authSuccess } from './userData';
@@ -27,7 +24,8 @@ export function facebookPromptLogin() {
 }
 
 export function facebookLoginWithAccessToken() {
-  return async (dispatch: ThunkDispatch<RootState, never, AnyAction>) => {
+  // @ts-ignore
+  return async dispatch => {
     try {
       const { accessToken, userID } =
         (await AccessToken.getCurrentAccessToken()) || {};
@@ -45,16 +43,16 @@ export function facebookLoginWithAccessToken() {
   };
 }
 
-function facebookLoginAction(accessToken: string, facebookId?: string) {
-  return async (
-    dispatch: ThunkDispatch<RootState, never, AnyAction>,
-    getState: () => RootState,
-  ) => {
+// @ts-ignore
+function facebookLoginAction(accessToken, facebookId) {
+  // @ts-ignore
+  return async (dispatch, getState) => {
     const { upgradeToken } = getState().auth;
 
     await dispatch(
       retryIfInvalidatedClientToken(
         loginWithFacebookAccessToken(accessToken, upgradeToken),
+        // @ts-ignore
         loginWithFacebookAccessToken(accessToken),
       ),
     );
@@ -62,10 +60,8 @@ function facebookLoginAction(accessToken: string, facebookId?: string) {
   };
 }
 
-const loginWithFacebookAccessToken = (
-  fb_access_token: string,
-  client_token?: string | null,
-) =>
+// @ts-ignore
+const loginWithFacebookAccessToken = (fb_access_token, client_token) =>
   callApi(
     REQUESTS.FACEBOOK_LOGIN,
     {},
@@ -76,7 +72,8 @@ const loginWithFacebookAccessToken = (
   );
 
 export function refreshMissionHubFacebookAccess() {
-  return async (dispatch: ThunkDispatch<RootState, never, AnyAction>) => {
+  // @ts-ignore
+  return async dispatch => {
     try {
       try {
         await AccessToken.refreshCurrentAccessTokenAsync();

--- a/src/actions/auth/key.ts
+++ b/src/actions/auth/key.ts
@@ -7,18 +7,16 @@ import { Linking } from 'react-native';
 // @ts-ignore
 import randomString from 'random-string';
 import Config from 'react-native-config';
-import { ThunkDispatch } from 'redux-thunk';
-import { AnyAction } from 'redux';
 
 import { THE_KEY_CLIENT_ID } from '../../constants';
 import callApi from '../api';
 import { REQUESTS } from '../../api/routes';
-import { RootState } from '../../reducers';
 
 import { retryIfInvalidatedClientToken } from './auth';
 import { authSuccess } from './userData';
 
-export function openKeyURL(baseURL: string) {
+// @ts-ignore
+export function openKeyURL(baseURL) {
   return () => {
     global.Buffer = global.Buffer || Buffer.Buffer;
 
@@ -52,7 +50,8 @@ export function openKeyURL(baseURL: string) {
   };
 }
 
-export function keyLogin(email: string, password: string, mfaCode: string) {
+// @ts-ignore
+export function keyLogin(email, password, mfaCode) {
   const data =
     `grant_type=password&client_id=${THE_KEY_CLIENT_ID}&scope=fullticket%20extended` +
     `&username=${encodeURIComponent(email)}&password=${encodeURIComponent(
@@ -62,34 +61,30 @@ export function keyLogin(email: string, password: string, mfaCode: string) {
   return getTokenAndLogin(data);
 }
 
-export function keyLoginWithAuthorizationCode(
-  code: string,
-  codeVerifier: string,
-  redirectUri: string,
-) {
+// @ts-ignore
+export function keyLoginWithAuthorizationCode(code, codeVerifier, redirectUri) {
   const data = `grant_type=authorization_code&client_id=${THE_KEY_CLIENT_ID}&code=${code}&code_verifier=${codeVerifier}&redirect_uri=${redirectUri}`;
 
   return getTokenAndLogin(data);
 }
 
 export function refreshAccessToken() {
-  return async (
-    dispatch: ThunkDispatch<RootState, never, AnyAction>,
-    getState: () => RootState,
-  ) => {
+  // @ts-ignore
+  return async (dispatch, getState) => {
     const data = `grant_type=refresh_token&refresh_token=${
       getState().auth.refreshToken
     }`;
 
     // @ts-ignore
     await dispatch(callApi(REQUESTS.KEY_REFRESH_TOKEN, {}, data));
-    return dispatch(getTicketAndLogin());
+    dispatch(getTicketAndLogin());
   };
 }
 
 // @ts-ignore
 function getTokenAndLogin(data) {
-  return async (dispatch: ThunkDispatch<RootState, never, AnyAction>) => {
+  // @ts-ignore
+  return async dispatch => {
     await dispatch(callApi(REQUESTS.KEY_LOGIN, {}, data));
     await dispatch(getTicketAndLogin());
 
@@ -98,23 +93,23 @@ function getTokenAndLogin(data) {
 }
 
 function getTicketAndLogin() {
-  return async (
-    dispatch: ThunkDispatch<RootState, never, AnyAction>,
-    getState: () => RootState,
-  ) => {
+  // @ts-ignore
+  return async (dispatch, getState) => {
     const { upgradeToken } = getState().auth;
     const { ticket } = await dispatch(callApi(REQUESTS.KEY_GET_TICKET, {}, {}));
 
     await dispatch(
       retryIfInvalidatedClientToken(
         loginWithKeyTicket(ticket, upgradeToken),
+        // @ts-ignore
         loginWithKeyTicket(ticket),
       ),
     );
   };
 }
 
-const loginWithKeyTicket = (ticket: string, client_token?: string | null) =>
+// @ts-ignore
+const loginWithKeyTicket = (ticket, client_token) =>
   callApi(
     REQUESTS.TICKET_LOGIN,
     {},

--- a/src/actions/auth/userData.ts
+++ b/src/actions/auth/userData.ts
@@ -14,19 +14,18 @@ import { REQUESTS } from '../../api/routes';
 import { getMyCommunities } from '../organizations';
 import { logInAnalytics } from '../analytics';
 import { rollbar } from '../../utils/rollbar.config';
+import { AuthState } from '../../reducers/auth';
 import { requestNativePermissions } from '../notifications';
 import { isAndroid } from '../../utils/common';
-import { RootState } from '../../reducers';
+import { AnalyticsState } from '../../reducers/analytics';
 
 function getTimezoneString() {
   return `${(new Date().getTimezoneOffset() / 60) * -1}`;
 }
 
 export function updateLocaleAndTimezone() {
-  return (
-    dispatch: ThunkDispatch<RootState, never, AnyAction>,
-    getState: () => RootState,
-  ) => {
+  // @ts-ignore
+  return (dispatch, getState) => {
     const {
       person: { user },
     } = getState().auth;
@@ -48,8 +47,12 @@ export function updateLocaleAndTimezone() {
 
 export function authSuccess() {
   return async (
-    dispatch: ThunkDispatch<RootState, null, AnyAction>,
-    getState: () => RootState,
+    dispatch: ThunkDispatch<
+      { auth: AuthState; analytics: AnalyticsState },
+      null,
+      AnyAction
+    >,
+    getState: () => { auth: AuthState },
   ) => {
     dispatch(logInAnalytics());
 
@@ -74,8 +77,8 @@ export function authSuccess() {
 
 export function loadHome() {
   return (
-    dispatch: ThunkDispatch<RootState, never, AnyAction>,
-    getState: () => RootState,
+    dispatch: ThunkDispatch<never, never, never>,
+    getState: () => { auth: AuthState },
   ) => {
     // Don't try to run all these things if there is no token
     if (!getState().auth.token) {

--- a/src/apolloClient.ts
+++ b/src/apolloClient.ts
@@ -16,67 +16,50 @@ import introspectionQueryResultData from '../schema.json';
 
 import { BASE_URL } from './api/utils';
 import { store } from './store';
-import {
-  EXPIRED_ACCESS_TOKEN,
-  INVALID_ACCESS_TOKEN,
-  UPDATE_TOKEN,
-} from './constants';
+import { UPDATE_TOKEN } from './constants';
 import { rollbar } from './utils/rollbar.config';
 import { typeDefs, resolvers, initializeLocalState } from './apolloLocalState';
-import { handleInvalidAccessToken } from './actions/auth/auth';
 
 export let apolloClient: ApolloClient<NormalizedCacheObject>;
 
 export const createApolloClient = async () => {
-  const rollbarLink = onError(
-    ({ graphQLErrors, networkError, forward, operation }) => {
-      if (graphQLErrors) {
-        graphQLErrors.forEach(error => {
-          if (
-            graphQLErrors.some(
-              ({ message }) =>
-                message === EXPIRED_ACCESS_TOKEN ||
-                message === INVALID_ACCESS_TOKEN,
-            )
-          ) {
-            (async () => {
-              // @ts-ignore TODO: Remove after https://github.com/CruGlobal/missionhub-react-native/pull/1852 is merged
-              await store.dispatch(handleInvalidAccessToken());
-              forward(operation);
-            })();
-          } else {
-            const errorMessage = `[Apollo GraphQL error]: ${error.message}`;
-            rollbar.error(errorMessage, error);
-            // eslint-disable-next-line no-console
-            console.log(errorMessage, error);
-          }
-        });
-      }
-      if (networkError) {
-        const errorMessage = `[Apollo Network error]: ${networkError.message}`;
-        rollbar.error(errorMessage, networkError);
+  const rollbarLink = onError(({ graphQLErrors, networkError }) => {
+    if (graphQLErrors) {
+      graphQLErrors.forEach(error => {
+        const errorMessage = `[Apollo GraphQL error]: ${error.message}`;
+        rollbar.error(errorMessage, error);
         // eslint-disable-next-line no-console
-        console.log(errorMessage, networkError);
-      }
-    },
-  );
+        console.log(errorMessage, error);
+      });
+    }
+    if (networkError) {
+      const errorMessage = `[Apollo Network error]: ${networkError.message}`;
+      rollbar.error(errorMessage, networkError);
+      // eslint-disable-next-line no-console
+      console.log(errorMessage, networkError);
+    }
+  });
 
   const authLink = new ApolloLink((operation, forward) => {
     operation.setContext({
       headers: { authorization: `Bearer ${store.getState().auth.token}` },
     });
-    return forward(operation).map(data => {
-      const sessionHeader = operation
-        .getContext()
-        .response.headers.get('X-MH-Session');
+    return (
+      (forward &&
+        forward(operation).map(data => {
+          const sessionHeader = operation
+            .getContext()
+            .response.headers.get('X-MH-Session');
 
-      sessionHeader &&
-        store.dispatch({
-          type: UPDATE_TOKEN,
-          token: sessionHeader,
-        });
-      return data;
-    });
+          sessionHeader &&
+            store.dispatch({
+              type: UPDATE_TOKEN,
+              token: sessionHeader,
+            });
+          return data;
+        })) ||
+      null
+    );
   });
 
   const uploadLink = createUploadLink({

--- a/src/components/ErrorNotice/ErrorNotice.tsx
+++ b/src/components/ErrorNotice/ErrorNotice.tsx
@@ -40,8 +40,7 @@ export const ErrorNotice = ({
     }, []);
 
   return error ? (
-    // Wrapped refetch in function to avoid passing native event to variables argument
-    <Touchable style={styles.errorContainer} onPress={() => refetch()}>
+    <Touchable style={styles.errorContainer} onPress={refetch}>
       {error.networkError ? (
         <Text style={styles.white}>{t('offline')}</Text>
       ) : matchedErrors && matchedErrors.length > 0 ? (


### PR DESCRIPTION
Reverts CruGlobal/missionhub-react-native#1875

There's an issue with sign out still firing `handleInvalidAccessToken` and navigating to sign in.