### PR TITLE
Fix-MembersList-First-Kabob-Not-Working

### DIFF
--- a/src/containers/Communities/Community/CommunityMembers/__tests__/__snapshots__/CommunityMembers.tsx.snap
+++ b/src/containers/Communities/Community/CommunityMembers/__tests__/__snapshots__/CommunityMembers.tsx.snap
@@ -341,7 +341,7 @@ exports[`CommunityMembers renders with content 1`] = `
       style={
         Object {
           "paddingHorizontal": 20,
-          "paddingVertical": 60,
+          "paddingTop": 60,
         }
       }
     >
@@ -1005,7 +1005,7 @@ exports[`CommunityMembers should render empty state 1`] = `
       style={
         Object {
           "paddingHorizontal": 20,
-          "paddingVertical": 60,
+          "paddingTop": 60,
         }
       }
     >
@@ -1295,7 +1295,7 @@ exports[`CommunityMembers should render loading state 1`] = `
       style={
         Object {
           "paddingHorizontal": 20,
-          "paddingVertical": 60,
+          "paddingTop": 60,
         }
       }
     >

--- a/src/containers/Communities/Community/CommunityMembers/styles.ts
+++ b/src/containers/Communities/Community/CommunityMembers/styles.ts
@@ -23,7 +23,7 @@ export default StyleSheet.create({
   },
   closeWrap: {
     paddingHorizontal: 20,
-    paddingVertical: 60,
+    paddingTop: 60,
   },
   close: {
     margin: 2,


### PR DESCRIPTION
The padding was covering the first list items kabob. Changing it to top padding only fixed this issue and had the same visual results as before.