### PR TITLE
Switch to https for cloning cru-fastlane-files

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,7 +1,7 @@
 cocoapods repo_update: true
 
 import_from_git(
-    url: 'git@github.com:CruGlobal/cru-fastlane-files.git',
+    url: 'https://github.com/CruGlobal/cru-fastlane-files',
     branch: 'master',
     path: 'Fastfile'
 )


### PR DESCRIPTION
Idk how much this will solve but seems like a step in the right direction.