### PR TITLE
MHP Fix GitHub actions build and push to testflight

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,9 @@ on:
 env:
   ENVFILE: ${{ (github.ref == 'refs/heads/master' || github.base_ref == 'refs/heads/master') && '.env.production' || '.env.staging' }}
 
+# Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -265,6 +265,12 @@ jobs:
         run: echo -e "machine github.com\n login $CI_USER_TOKEN" >> ~/.netrc
         env:
           CI_USER_TOKEN: ${{ secrets.CI_USER_TOKEN}}
+      - name: Import App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_API_JSON_PAYLOAD: ${{ secrets.APP_STORE_CONNECT_API_JSON_PAYLOAD }}
+        run: echo $APP_STORE_CONNECT_API_JSON_PAYLOAD > ios/fastlane/AppleAppStoreApi.json
+      - name: Increment Xcode Project Build Number
+        run: bundle exec fastlane cru_shared_lane_increment_xcode_project_build_number
       - name: 🏗️🚀🍏 Build and push to Testflight
         uses: maierj/fastlane-action@v2.0.0
         with:

--- a/ios/.env.default
+++ b/ios/.env.default
@@ -1,5 +1,6 @@
-## Fastlane Build variables
-SPACESHIP_SKIP_2FA_UPGRADE=1
+
+APP_RELEASE_BUNDLE_IDENTIFIER = "com.missionhub"
+APP_STORE_CONNECT_API_KEY_JSON_FILE_PATH = "./ios/fastlane/AppleAppStoreAPI.json"
 
 ## Fastlane Build - Project related variables
 CRU_FASTLANE_USERNAME="cruapps@cru.org"


### PR DESCRIPTION
This PR adds the app store connect api key and also runs lane ```cru_shared_lane_increment_xcode_project_build_number```.  There's still a little more work to be done, but would like to merge this into develop so I can manually trigger the workflow.  Added the ```workflow_dispatch``` trigger in this PR.