### PR TITLE
MHP - Update fastlane version and run on cru shared lanes instead of beta lane

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -268,23 +268,25 @@ jobs:
         run: echo -e "machine github.com\n login $CI_USER_TOKEN" >> ~/.netrc
         env:
           CI_USER_TOKEN: ${{ secrets.CI_USER_TOKEN}}
+      - name: Bundle Install
+        run: bundle install
       - name: Import App Store Connect API Key
         env:
           APP_STORE_CONNECT_API_JSON_PAYLOAD: ${{ secrets.APP_STORE_CONNECT_API_JSON_PAYLOAD }}
         run: echo $APP_STORE_CONNECT_API_JSON_PAYLOAD > ios/fastlane/AppleAppStoreApi.json
+      - name: Increment Xcode Project Build Number
+        uses: maierj/fastlane-action@v2.0.0
+        with:
+          lane: ios cru_shared_lane_increment_xcode_project_build_number
+          subdirectory: ios
       - name: 🏗️🚀🍏 Build and push to Testflight
         uses: maierj/fastlane-action@v2.0.0
         with:
-          lane: ios beta
+          lane: ios cru_shared_lane_build_and_deploy_for_testflight_release is_running_in_ci:true
           subdirectory: ios
         env:
-          TRAVIS_BRANCH: ${{ github.ref }}
-          TRAVIS_TAG: ${{ github.ref }}
-          TRAVIS_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          TRAVIS_BUILD_NUMBER: ${{ github.run_id }}
+          MATCH_GIT_BASIC_AUTHORIZATION_PAT: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION_PAT }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
-          SLACK_URL: ${{ secrets.SLACK_URL }}
 
   android-deploy:
     runs-on: ubuntu-latest

--- a/ios/.env.default
+++ b/ios/.env.default
@@ -1,20 +1,19 @@
 
-CRU_API_KEY_PATH = "./fastlane/AppleAppStoreAPI.json"
+APP_RELEASE_BUNDLE_IDENTIFIER = "com.missionhub"
+APP_STORE_CONNECT_API_KEY_JSON_FILE_PATH = "./fastlane/AppleAppStoreAPI.json"
 
-## Fastlane Build - Project related variables
-CRU_FASTLANE_USERNAME="cruapps@cru.org"
-CRU_APP_IDENTIFIER="com.missionhub"
-CRU_TARGET="MissionHub"
-CRU_SCHEME="MissionHub"
-CRU_XCODEPROJ="MissionHub.xcodeproj"
-CRU_DEV_PORTAL_TEAM_ID="DQ48D9BF2V"
+## Code Signing 
+CODE_SIGNING_APP_BUNDLE_IDS = "com.missionhub"
+CODE_SIGNING_PROVISIONING_PROFILE_NAMES = "match AppStore com.missionhub"
+CODE_SIGNING_TARGETS = "MissionHub"
+CODE_SIGNING_TEAM_ID = "DQ48D9BF2V"
 
-CRU_DEFAULT_BRANCH="master"
-CRU_SKIP_COCOAPODS="true"
+## Match
+MATCH_GIT_BRANCH = "master"
+MATCH_GIT_URL = "https://github.com/CruGlobal/ios-signing-credentials"
+MATCH_KEYCHAIN_NAME = "MissionHub"
 
-## Fastlane Build - Localization related variables
-CRU_SKIP_LOCALIZATION_DOWNLOAD="true"  # this is handled separately through a yarn script
-
-## Fastlane Build - Code signing related variables
-CRU_APPSTORE_PROFILE_NAME="match AppStore com.missionhub"
-MATCH_KEYCHAIN_NAME=MissionHub
+## Gym
+GYM_RELEASE_APP_BUNDLE_IDENTIFIER = "com.missionhub"
+GYM_RELEASE_PROVISIONING_PROFILE = "match AppStore com.missionhub"
+GYM_RELEASE_SCHEME = "MissionHub"


### PR DESCRIPTION
Trying the cru shared lanes again this time with bundle install to update Fastlane to the latest version.

Tried running the beta lane, but it looks like some updates will be needed to that lane as it's using a deprecated automatic code signing in Fastlane.

<img width="576" alt="Screenshot 2023-09-12 at 9 35 09 AM" src="https://github.com/CruGlobal/missionhub-react-native/assets/59846460/84140dd0-8103-47a0-8af6-17217ddc1cc0">
